### PR TITLE
Remove node id title changes

### DIFF
--- a/backend/src/diffbot_transformer.py
+++ b/backend/src/diffbot_transformer.py
@@ -14,7 +14,6 @@ def get_graph_from_diffbot(graph,chunkId_chunkDoc_list:List):
     diffbot_api_key = os.environ.get('DIFFBOT_API_KEY')
     diffbot_nlp = DiffbotGraphTransformer(diffbot_api_key=diffbot_api_key)
     graph_documents = diffbot_nlp.convert_to_graph_documents(combined_chunk_document_list)
-    graph.add_graph_documents(graph_documents, baseEntityLabel=True)
     return graph_documents
 
     

--- a/backend/src/gemini_llm.py
+++ b/backend/src/gemini_llm.py
@@ -525,8 +525,7 @@ def get_graph_from_Gemini(model_version,
             
             #Sleep for 1 sec after 4 requestes are processed. 
             # Todo: Remove this code block when Gemini rate limit is increased 
-            if i % 4 == 0 :
-                time.sleep(1)
+            # if i % 4 == 0 :
+            #     time.sleep(1)
         
-    graph.add_graph_documents(graph_document_list, baseEntityLabel=True)
     return  graph_document_list

--- a/backend/src/gemini_llm.py
+++ b/backend/src/gemini_llm.py
@@ -517,10 +517,10 @@ def get_graph_from_Gemini(model_version,
             # nodes = [Node(id=id, type=type) for id,type in unique_nodes]        
             # graph_document[0].nodes=list(nodes)
 
-            for node in graph_document[0].nodes:
-               node.id = node.id.title().replace(' ','_')
-                # replace all non alphanumeric characters and spaces with underscore
-               node.type = re.sub(r'[^\w]+', '_', node.type.capitalize())
+#            for node in graph_document[0].nodes:
+#               node.id = node.id.title().replace(' ','_')
+#                # replace all non alphanumeric characters and spaces with underscore
+#               node.type = re.sub(r'[^\w]+', '_', node.type.capitalize())
             graph_document_list.append(graph_document[0])
             
             #Sleep for 1 sec after 4 requestes are processed. 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -247,6 +247,7 @@ def processing_source(graph, model, file_name, pages, allowedNodes, allowedRelat
     update_embedding_create_vector_index( graph, chunkId_chunkDoc_list, file_name)
     logging.info("Get graph document list from models")
     graph_documents =  generate_graphDocuments(model, graph, chunkId_chunkDoc_list, allowedNodes, allowedRelationship)
+    save_graphDocuments_in_neo4j(graph, graph_documents)
     
     chunks_and_graphDocuments_list = get_chunk_and_graphDocument(graph_documents, chunkId_chunkDoc_list)
     merge_relationship_between_chunk_and_entites(graph, chunks_and_graphDocuments_list)

--- a/backend/src/openAI_llm.py
+++ b/backend/src/openAI_llm.py
@@ -477,7 +477,6 @@ def get_graph_from_OpenAI(model_version, graph, chunkId_chunkDoc_list, allowedNo
 #                #replace all non alphanumeric characters and spaces with underscore
 #                node.type = re.sub(r'[^\w]+', '_', node.type.capitalize())
             graph_document_list.append(graph_document[0])    
-    graph.add_graph_documents(graph_document_list, baseEntityLabel=True)
     return  graph_document_list        
         
     

--- a/backend/src/openAI_llm.py
+++ b/backend/src/openAI_llm.py
@@ -472,10 +472,10 @@ def get_graph_from_OpenAI(model_version, graph, chunkId_chunkDoc_list, allowedNo
         
         for i, future in enumerate(concurrent.futures.as_completed(futures)):
             graph_document = future.result()
-            for node in graph_document[0].nodes:
-                node.id = node.id.title().replace(' ','_')
-                #replace all non alphanumeric characters and spaces with underscore
-                node.type = re.sub(r'[^\w]+', '_', node.type.capitalize())
+#            for node in graph_document[0].nodes:
+#                node.id = node.id.title().replace(' ','_')
+#                #replace all non alphanumeric characters and spaces with underscore
+#                node.type = re.sub(r'[^\w]+', '_', node.type.capitalize())
             graph_document_list.append(graph_document[0])    
     graph.add_graph_documents(graph_document_list, baseEntityLabel=True)
     return  graph_document_list        

--- a/backend/src/shared/common_fn.py
+++ b/backend/src/shared/common_fn.py
@@ -5,6 +5,8 @@ from langchain_google_vertexai import VertexAIEmbeddings
 from langchain_openai import OpenAIEmbeddings
 from langchain.docstore.document import Document
 from langchain_community.graphs import Neo4jGraph
+from langchain_community.graphs.graph_document import GraphDocument
+from typing import List
 import re
 import os
 
@@ -67,4 +69,7 @@ def load_embedding_model(embedding_model_name: str):
         dimension = 384
         logging.info(f"Embedding: Using SentenceTransformer , Dimension:{dimension}")
     return embeddings, dimension
+
+def save_graphDocuments_in_neo4j(graph:Neo4jGraph, graph_document_list:List[GraphDocument]):
+  graph.add_graph_documents(graph_document_list, baseEntityLabel=True)  
                  


### PR DESCRIPTION
Currently we change the id and type of the nodes.
But those are not reflected in the relationship entries which causes them to be not connected anymore.
Also then the nodes for the relationships don't have the right label/type anymore.

Let's keep the types and id's as we get them from the LLM for the time being.

If we want to change it later, we need to do it on both places.

General observations:

1. Such kind of processing should also not happen inside the LLM methods but outside when the list of graph-documents is further processed.
2. Also we had discussed not doing the store in graph inside of the LLM methods but as a next step in the processing, seems that has not been fixed, so we still have this duplicate code in the wrong place.