### PR TITLE
Relationship emb refactor

### DIFF
--- a/backend/src/make_relationships.py
+++ b/backend/src/make_relationships.py
@@ -47,10 +47,10 @@ def update_embedding_create_vector_index(graph, chunkId_chunkDoc_list, file_name
     logging.info(f"update embedding and vector index for chunks")
     for row in chunkId_chunkDoc_list:
         # for graph_document in row['graph_doc']:
-        embeddings_arr = embeddings.embed_query(row['chunk_doc'].page_content)
-        # logging.info(f'Embedding list {embeddings}')
         if isEmbedding.upper() == "TRUE":
-
+            embeddings_arr = embeddings.embed_query(row['chunk_doc'].page_content)
+            # logging.info(f'Embedding list {embeddings_arr}')
+                                    
             data_for_query.append({
                 "chunkId": row['chunk_id'],
                 "embeddings": embeddings_arr


### PR DESCRIPTION
https://github.com/neo4j-labs/llm-graph-builder/blob/1dd103b3f1e1d32e296a5b5454730cf340ddfac0/backend/src/make_relationships.py#L50

Issue: Presently the embedding are being created even if they are not being used, for rare cases this might lead to unnecessary latency & embedding creation cost
```
embeddings_arr = embeddings.embed_query(row['chunk_doc'].page_content)
# logging.info(f'Embedding list {embeddings}')
if isEmbedding.upper() == "TRUE":
    data_for_query.append({
        "chunkId": row['chunk_id'],
        "embeddings": embeddings_arr
    })
```

Solution: only calculate embedding when used 
```
if isEmbedding.upper() == "TRUE":
    embeddings_arr = embeddings.embed_query(row['chunk_doc'].page_content)
```