### PR TITLE
Switch frontend port in docker-compose to 8080 to match with the fron…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - REACT_APP_SOURCES=${REACT_APP_SOURCES}
     container_name: frontend
     ports:
-      - "5173:5173"
+      - "8080:8080"
     networks:
       - net
 


### PR DESCRIPTION
[Issue 301](https://github.com/neo4j-labs/llm-graph-builder/issues/301)

Changed the port in the docker-compose for the frontend from 5173 to 8080 since the Dockerfile expose it through nginx on 8080.