### PR TITLE
Fix .env

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,24 +1,24 @@
 # Mandatory
-OPENAI_API_KEY = ""
-DIFFBOT_API_KEY = ""
+OPENAI_API_KEY=""
+DIFFBOT_API_KEY=""
 
 # Optional Backend
-EMBEDDING_MODEL = "all-MiniLM-L6-v2"
-IS_EMBEDDING = "true"
-KNN_MIN_SCORE = "0.94"
+EMBEDDING_MODEL="all-MiniLM-L6-v2"
+IS_EMBEDDING="true"
+KNN_MIN_SCORE="0.94"
 # Enable Gemini (default is False) | Can be False or True
-GEMINI_ENABLED = False
+GEMINI_ENABLED=False
 # Enable Google Cloud logs (default is False) | Can be False or True
-GCP_LOG_METRICS_ENABLED = False
-NUMBER_OF_CHUNKS_TO_COMBINE = 6
-UPDATE_GRAPH_CHUNKS_PROCESSED = 20
-NEO4J_URI = "neo4j://database:7687"
-NEO4J_USERNAME = "neo4j"
-NEO4J_PASSWORD = "password"
-LANGCHAIN_API_KEY = ""
-LANGCHAIN_PROJECT = ""
-LANGCHAIN_TRACING_V2 = "true"
-LANGCHAIN_ENDPOINT = "https://api.smith.langchain.com"
+GCP_LOG_METRICS_ENABLED=False
+NUMBER_OF_CHUNKS_TO_COMBINE=6
+UPDATE_GRAPH_CHUNKS_PROCESSED=20
+NEO4J_URI="neo4j://database:7687"
+NEO4J_USERNAME="neo4j"
+NEO4J_PASSWORD="password"
+LANGCHAIN_API_KEY=""
+LANGCHAIN_PROJECT=""
+LANGCHAIN_TRACING_V2="true"
+LANGCHAIN_ENDPOINT="https://api.smith.langchain.com"
 
 # Optional Frontend
 BACKEND_API_URL="http://localhost:8000"


### PR DESCRIPTION
remove spaced before and after environment variable assignments " = "

```
.env:2: command not found: OPENAI_API_KEY
.env:3: command not found: DIFFBOT_API_KEY
.env:6: command not found: EMBEDDING_MODEL
.env:7: command not found: IS_EMBEDDING
.env:8: command not found: KNN_MIN_SCORE
.env:10: command not found: GEMINI_ENABLED
.env:12: command not found: GCP_LOG_METRICS_ENABLED
.env:13: command not found: NUMBER_OF_CHUNKS_TO_COMBINE
.env:14: command not found: UPDATE_GRAPH_CHUNKS_PROCESSED
.env:15: command not found: NEO4J_URI
.env:16: command not found: NEO4J_USERNAME
.env:17: command not found: NEO4J_PASSWORD
.env:18: command not found: LANGCHAIN_API_KEY
.env:19: command not found: LANGCHAIN_PROJECT
.env:20: command not found: LANGCHAIN_TRACING_V2
.env:21: command not found: LANGCHAIN_ENDPOINT
```