### PR TITLE
Adding sort rows on the table

### DIFF
--- a/frontend/src/components/FileTable.tsx
+++ b/frontend/src/components/FileTable.tsx
@@ -21,6 +21,7 @@ import {
   CellContext,
   Table,
   Row,
+  getSortedRowModel
 } from '@tanstack/react-table';
 import { useFileContext } from '../context/UsersFiles';
 import { getSourceNodes } from '../services/GetFiles';
@@ -579,6 +580,8 @@ const FileTable: React.FC<FileTableProps> = ({ isExpanded, connectionStatus, set
     enableRowSelection: true,
     enableMultiRowSelection: true,
     getRowId: (row) => JSON.stringify({ ...row }),
+    enableSorting: true,
+    getSortedRowModel: getSortedRowModel()
   });
 
   useEffect(() => {


### PR DESCRIPTION
Enabling the sorting features on the datagrid using getSortedRow from react-table