### PR TITLE
fix: pip install package

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -59,7 +59,7 @@ huggingface-hub
 humanfriendly==10.0
 idna==3.6
 importlib-resources==6.1.1
-install==1.3.5
+pip-install==1.3.5
 iopath==0.1.10
 Jinja2==3.1.3
 jmespath==1.0.1


### PR DESCRIPTION
**Change lib`install` into `pip-install`**

**Description:**
The package to install pip packages from within code has becomes `pip-install` instead of `install`
`pip install install` will result in error.
