### PR TITLE
fix: props not defined in pageLayout component

### DIFF
--- a/frontend/src/components/QuickStarter.tsx
+++ b/frontend/src/components/QuickStarter.tsx
@@ -11,7 +11,6 @@ const QuickStarter: React.FunctionComponent = () => {
   const themeUtils = React.useContext(ThemeWrapperContext);
   const [themeMode, setThemeMode] = useState<string>(themeUtils.colorMode);
   const [showSettingsModal, setshowSettingsModal] = useState<boolean>(false);
-  const [showOrphanNodeDeletionDialog, setshowOrphanNodeDeletionDialog] = useState<boolean>(false);
 
   const toggleColorMode = () => {
     setThemeMode((prevThemeMode) => {
@@ -25,12 +24,7 @@ const QuickStarter: React.FunctionComponent = () => {
   const closeSettingModal = () => {
     setshowSettingsModal(false);
   };
-  const openOrphanNodeDeletionModal = () => {
-    setshowOrphanNodeDeletionDialog(true);
-  };
-  const closeOrphanNodeDeletionModal = () => {
-    setshowOrphanNodeDeletionDialog(false);
-  };
+
   return (
     <UserCredentialsWrapper>
       <FileContextProvider>
@@ -41,9 +35,6 @@ const QuickStarter: React.FunctionComponent = () => {
               openSettingsDialog={openSettingsModal}
               isSettingPanelExpanded={showSettingsModal}
               closeSettingModal={closeSettingModal}
-              closeOrphanNodeDeletionModal={closeOrphanNodeDeletionModal}
-              showOrphanNodeDeletionModal={showOrphanNodeDeletionDialog}
-              openOrphanNodeDeletionModal={openOrphanNodeDeletionModal}
             />
           </AlertContextWrapper>
         </MessageContextWrapper>


### PR DESCRIPTION
**Remove props which are not defined in the pageLayout component**

Description:
For the frontend, yarn run build failed with error `closeOrphanNodeDeletionModal, showOrphanNodeDeletionModal, openOrphanNodeDeletionModal` not declared in the component `PageLayout`
