### PR TITLE
Handled Nonetype error during global search.

### DIFF
--- a/backend/src/QA_integration.py
+++ b/backend/src/QA_integration.py
@@ -278,7 +278,9 @@ def retrieve_documents(doc_retriever, messages):
     except Exception as e:
         error_message = f"Error retrieving documents: {str(e)}"
         logging.error(error_message)
-        raise RuntimeError(error_message)
+        docs = None
+        transformed_question = None
+
     
     return docs,transformed_question
 


### PR DESCRIPTION
Fixed Bug - For some documents when communities are not present application was throwing error
TypeError: '<' not supported between instances of 'NoneType' and 'float'