### PR TITLE
Delete query refined to delete all related nodes of file

### DIFF
--- a/backend/score.py
+++ b/backend/score.py
@@ -317,7 +317,7 @@ async def post_processing(uri=Form(), userName=Form(), password=Form(), database
     try:
         graph = create_graph_database_connection(uri, userName, password, database)
         tasks = set(map(str.strip, json.loads(tasks)))
-        count_response = ""
+        count_response = []
         start = time.time()
         if "materialize_text_chunk_similarities" in tasks:
             await asyncio.to_thread(update_graph, graph)


### PR DESCRIPTION
Updated delete document & communities queries to delete all related nodes. Resolved issue of residual nodes.
Also updated community count null error if communities are not created.