### PR TITLE
Updated code for duplicate nodes and index dimension mismatch

### DIFF
--- a/backend/src/graphDB_dataAccess.py
+++ b/backend/src/graphDB_dataAccess.py
@@ -362,7 +362,7 @@ class graphDBdataAccess:
         score_value = float(os.environ.get('DUPLICATE_SCORE_VALUE'))
         text_distance = int(os.environ.get('DUPLICATE_TEXT_DISTANCE'))
         query_duplicate_nodes = """
-                MATCH (n:!Chunk&!Session&!Document&!`__Community__`&!`__Entity__`) with n 
+                MATCH (n:!Chunk&!Session&!Document&!`__Community__`) with n 
                 WHERE n.embedding is not null and n.id is not null // and size(toString(n.id)) > 3
                 WITH n ORDER BY count {{ (n)--() }} DESC, size(toString(n.id)) DESC // updated
                 WITH collect(n) as nodes

--- a/backend/src/make_relationships.py
+++ b/backend/src/make_relationships.py
@@ -68,12 +68,12 @@ def update_embedding_create_vector_index(graph, chunkId_chunkDoc_list, file_name
             #                 "embeddings" : embeddings_arr
             #             }
             #             )
-            # logging.info('create vector index on chunk embedding')
-            result = graph.query("SHOW INDEXES YIELD * WHERE labelsOrTypes = ['__Chunk__'] and name = 'vector'")
+            logging.info('create vector index on chunk embedding')
+            # result = graph.query("SHOW INDEXES YIELD * WHERE labelsOrTypes = ['Chunk'] and name = 'vector'")
             vector_index = graph.query("SHOW INDEXES YIELD * WHERE labelsOrTypes = ['Chunk'] and type = 'VECTOR' AND name = 'vector' return options")
-            if result:
-                logging.info(f"vector index dropped for 'Chunk'")
-                graph.query("DROP INDEX vector IF EXISTS;")
+            # if result:
+            #     logging.info(f"vector index dropped for 'Chunk'")
+            #     graph.query("DROP INDEX vector IF EXISTS;")
 
             if len(vector_index) == 0:
                 logging.info(f'vector index is not exist, will create in next query')

--- a/backend/src/post_processing.py
+++ b/backend/src/post_processing.py
@@ -124,6 +124,10 @@ def create_fulltext(driver,type):
 
 def create_vector_fulltext_indexes(uri, username, password, database):
     types = ["entities", "hybrid"]
+    embedding_model = os.getenv('EMBEDDING_MODEL')
+    embeddings, dimension = load_embedding_model(embedding_model)
+    if not dimension:
+        dimension = CHUNK_VECTOR_EMBEDDING_DIMENSION
     logging.info("Starting the process of creating full-text indexes.")
 
     try:
@@ -144,7 +148,7 @@ def create_vector_fulltext_indexes(uri, username, password, database):
 
     try:
         logging.info(f"Creating a vector index for type '{CHUNK_VECTOR_INDEX_NAME}'.")
-        create_vector_index(driver, CHUNK_VECTOR_INDEX_NAME,CHUNK_VECTOR_EMBEDDING_DIMENSION)
+        create_vector_index(driver, CHUNK_VECTOR_INDEX_NAME,dimension)
         logging.info("Vector index for chunk created successfully.")
     except Exception as e:
         logging.error(f"Failed to create vector index for '{CHUNK_VECTOR_INDEX_NAME}': {e}")


### PR DESCRIPTION
Updated code for
- duplicate node not showing, removed  "not entity" from query
- Index dimension mismatch resolved as it was taking 384 by default for vector index in post processing.