### PR TITLE
Run yarn build when starting up frontend container

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,11 +1,12 @@
 # Step 1: Build the React application
-FROM node:20 AS build
+FROM quay.io/centos/centos:stream9-minimal
 
 ARG VITE_BACKEND_API_URL="http://localhost:8000"
 ARG VITE_REACT_APP_SOURCES=""
 ARG VITE_LLM_MODELS=""
 ARG VITE_GOOGLE_CLIENT_ID=""
-ARG VITE_BLOOM_URL="https://workspace-preview.neo4j.io/workspace/explore?connectURL={CONNECT_URL}&search=Show+me+a+graph&featureGenAISuggestions=true&featureGenAISuggestionsInternal=true"
+#ARG VITE_BLOOM_URL="https://workspace-preview.neo4j.io/workspace/explore?connectURL={CONNECT_URL}&search=Show+me+a+graph&featureGenAISuggestions=true&featureGenAISuggestionsInternal=true"
+ARG VITE_BLOOM_URL=""
 ARG VITE_TIME_PER_PAGE=50
 ARG VITE_LARGE_FILE_SIZE=5242880
 ARG VITE_CHUNK_SIZE=5242880
@@ -13,12 +14,18 @@ ARG VITE_CHAT_MODES=""
 ARG VITE_ENV="DEV"
 ARG VITE_BATCH_SIZE=2
 ARG VITE_LLM_MODELS_PROD="openai_gpt_4o,openai_gpt_4o_mini,diffbot,gemini_1.5_flash"
+ARG DEPLOYMENT_ENV="prod"
+ENV DEPLOYMENT_ENV=$DEPLOYMENT_ENV
 
 WORKDIR /app
+RUN microdnf install findutils tar gzip bzip2 nginx -y && microdnf clean all
+ADD https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh /tmp/nvm-install.sh
+RUN bash /tmp/nvm-install.sh && source /root/.bashrc && nvm install --lts && nvm use --lts && corepack use yarn && corepack enable
 COPY package.json yarn.lock ./
-RUN yarn install
+RUN source /root/.bashrc && yarn install
 COPY . ./
-RUN VITE_BACKEND_API_URL=$VITE_BACKEND_API_URL \
+RUN source /root/.bashrc && ls && yarn install && \
+    VITE_BACKEND_API_URL=$VITE_BACKEND_API_URL \
     VITE_REACT_APP_SOURCES=$VITE_REACT_APP_SOURCES \
     VITE_GOOGLE_CLIENT_ID=$VITE_GOOGLE_CLIENT_ID \
     VITE_BLOOM_URL=$VITE_BLOOM_URL \
@@ -32,12 +39,10 @@ RUN VITE_BACKEND_API_URL=$VITE_BACKEND_API_URL \
     VITE_LLM_MODELS_PROD=$VITE_LLM_MODELS_PROD \
     yarn run build
 
-# Step 2: Serve the application using Nginx
-FROM nginx:alpine
-ARG DEPLOYMENT_ENV="local"
-ENV DEPLOYMENT_ENV=$DEPLOYMENT_ENV
-COPY --from=build /app/dist /usr/share/nginx/html
-COPY /nginx/nginx.${DEPLOYMENT_ENV}.conf /etc/nginx/templates/nginx.conf.template
+COPY . ./
+RUN rm -rf /usr/share/nginx/html && ln -s /app/dist /usr/share/nginx/html
+COPY /nginx/nginx.${DEPLOYMENT_ENV}.conf /etc/nginx/conf.d/nginx.${DEPLOYMENT_ENV}.conf
+ADD entrypoint.sh /bin/
 
 EXPOSE 8080
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["bash", "/bin/entrypoint.sh"]

--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd /usr/share/nginx/html
+source /root/.bashrc
+yarn run build
+nginx -g "daemon off;"
+


### PR DESCRIPTION
# Problem statement

frontend docker container at the moment set conf iguration (`VITE_*` etc) during container build time, which means secrets (API keys etc) and configs are stored in the container image, and configuration could not be changed during `docker run`. This makes the workflow of uploading container image to container registry prior to deployment to not work properly. 

This pull request is a suggestion on modifying frontend Dockerfile to run `yarn build` when container is starting up so that config are applied during container start. 

I'm primarily Python+Linux programmer and not quite a frontend person and has low familiarity with `yarn build` and how it update config files, not sure if this is the right way to do it, but putting this request here for comment. 