### PR TITLE
fix: load existing schema

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -673,11 +673,11 @@ def get_labels_and_relationtypes(graph):
   query = """
           RETURN collect { 
           CALL db.labels() yield label 
-          WHERE NOT label  IN ['Document','Chunk','_Bloom_Perspective_', '__Community__', '__Entity__'] 
+          WHERE NOT label  IN ['Document','Chunk','_Bloom_Perspective_', '__Community__', '__Entity__', 'Session', 'Message'] 
           return label order by label limit 100 } as labels, 
           collect { 
           CALL db.relationshipTypes() yield relationshipType  as type 
-          WHERE NOT type  IN ['PART_OF', 'NEXT_CHUNK', 'HAS_ENTITY', '_Bloom_Perspective_','FIRST_CHUNK','SIMILAR','IN_COMMUNITY','PARENT_COMMUNITY'] 
+          WHERE NOT type  IN ['PART_OF', 'NEXT_CHUNK', 'HAS_ENTITY', '_Bloom_Perspective_','FIRST_CHUNK','SIMILAR','IN_COMMUNITY','PARENT_COMMUNITY', 'NEXT', 'LAST_MESSAGE'] 
           return type order by type LIMIT 100 } as relationshipTypes
           """
   graphDb_data_Access = graphDBdataAccess(graph)


### PR DESCRIPTION
When loading an existing knowledge graph schema, the labels of chatbot messages come with it.

![Screenshot 2025-02-09 093043](https://github.com/user-attachments/assets/4bde5a56-9244-49fb-a533-c506b8b458f8)
![Screenshot 2025-02-09 093314](https://github.com/user-attachments/assets/12f0aac1-5df3-4446-afa7-044c74060460)
