### PR TITLE
fix: visualize graph schema

### DIFF
--- a/backend/src/shared/constants.py
+++ b/backend/src/shared/constants.py
@@ -894,6 +894,11 @@ Instead, treat these as properties associated with the relevant entities."""
 
 SCHEMA_VISUALIZATION_QUERY = """
 CALL db.schema.visualization() YIELD nodes, relationships
+WITH 
+  [n IN nodes WHERE NONE(lbl IN labels(n) WHERE lbl IN ['Document','Chunk','_Bloom_Perspective_', '__Community__', '__Entity__','Session','Message'])]
+  AS nodes,
+  [r IN relationships WHERE NOT type(r) IN ['PART_OF', 'NEXT_CHUNK', 'HAS_ENTITY', '_Bloom_Perspective_','FIRST_CHUNK','SIMILAR','IN_COMMUNITY','PARENT_COMMUNITY','NEXT','LAST_MESSAGE']]
+  AS relationships
 RETURN
   [n IN nodes | {
       element_id: elementId(n),

--- a/backend/src/shared/constants.py
+++ b/backend/src/shared/constants.py
@@ -895,9 +895,9 @@ Instead, treat these as properties associated with the relevant entities."""
 SCHEMA_VISUALIZATION_QUERY = """
 CALL db.schema.visualization() YIELD nodes, relationships
 WITH 
-  [n IN nodes WHERE NONE(lbl IN labels(n) WHERE lbl IN ['Document','Chunk','_Bloom_Perspective_', '__Community__', '__Entity__','Session','Message'])]
+  [n IN nodes WHERE NONE(lbl IN labels(n) WHERE lbl IN ['__Entity__','Session','Message'])]
   AS nodes,
-  [r IN relationships WHERE NOT type(r) IN ['PART_OF', 'NEXT_CHUNK', 'HAS_ENTITY', '_Bloom_Perspective_','FIRST_CHUNK','SIMILAR','IN_COMMUNITY','PARENT_COMMUNITY','NEXT','LAST_MESSAGE']]
+  [r IN relationships WHERE NOT type(r) IN ['NEXT','LAST_MESSAGE']]
   AS relationships
 RETURN
   [n IN nodes | {


### PR DESCRIPTION
When visualizing the graph schema, the labels of chatbot messages are included, and the node labeled __Entity__ is included and centralizes the network.

![Screenshot 2025-02-09 165129](https://github.com/user-attachments/assets/1ab880fd-8293-409b-aff9-381a19747bd8)
