### PR TITLE
Enhance Relationship Extraction with Three-Tuple Approach in LLMGraphTransformer

### DIFF
--- a/backend/src/llm.py
+++ b/backend/src/llm.py
@@ -14,6 +14,7 @@ from langchain_community.chat_models import ChatOllama
 import boto3
 import google.auth
 from src.shared.constants import ADDITIONAL_INSTRUCTIONS
+import json
 
 def get_llm(model: str):
     """Retrieve the specified language model based on the model name."""
@@ -200,8 +201,11 @@ async def get_graph_from_llm(model, chunkId_chunkDoc_list, allowedNodes, allowed
         if  allowedRelationship is None or allowedRelationship=="":   
             allowedRelationship=[]
         else:
-            allowedRelationship = allowedRelationship.split(',')
-            
+            data = json.loads(allowedRelationship)
+            if isinstance(data, list) and data and isinstance(data[0], list):
+                allowedRelationship = [tuple(item) for item in data]
+            else:
+                allowedRelationship = data           
         graph_document_list = await get_graph_document_list(
             llm, combined_chunk_document_list, allowedNodes, allowedRelationship, additional_instructions
         )

--- a/frontend/src/components/Content.tsx
+++ b/frontend/src/components/Content.tsx
@@ -291,7 +291,9 @@ const Content: React.FC<ContentProps> = ({
         fileItem.gcsBucket ?? '',
         fileItem.gcsBucketFolder ?? '',
         selectedNodes.map((l) => l.value),
-        selectedRels.map((t) => t.value),
+        selectedRels.every((t) => t.value.split(',').length === 3)
+        ? selectedRels.map((t) => t.value.split(',') as [string, string, string])
+        : selectedRels.map((t) => t.value),
         selectedTokenChunkSize,
         selectedChunk_overlap,
         selectedChunks_to_combine,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -81,7 +81,7 @@ export type ExtractParams = Pick<CustomFile, 'wikiQuery' | 'model' | 'sourceUrl'
   source_type?: string;
   file_name?: string;
   allowedNodes?: string[];
-  allowedRelationship?: string[];
+  allowedRelationship?: string;
   gcs_project_id?: string;
   retry_condition: string;
   additional_instructions?: string;

--- a/frontend/src/utils/FileAPI.ts
+++ b/frontend/src/utils/FileAPI.ts
@@ -41,6 +41,7 @@ export const extractAPI = async (
 ): Promise<any> => {
   const urlExtract = `${url()}/extract`;
   const method: Method = 'post';
+  const allowedRelationshipString = JSON.stringify(allowedRelationship)
   let additionalParams: ExtractParams;
   if (source_type === 's3 bucket') {
     additionalParams = {
@@ -51,7 +52,7 @@ export const extractAPI = async (
       source_type,
       file_name,
       allowedNodes,
-      allowedRelationship,
+      allowedRelationship: allowedRelationshipString,
       token_chunk_size,
       chunk_overlap,
       chunks_to_combine,
@@ -65,7 +66,7 @@ export const extractAPI = async (
       source_type,
       file_name,
       allowedNodes,
-      allowedRelationship,
+      allowedRelationship: allowedRelationshipString,
       token_chunk_size,
       chunk_overlap,
       chunks_to_combine,
@@ -82,7 +83,7 @@ export const extractAPI = async (
       source_type,
       file_name,
       allowedNodes,
-      allowedRelationship,
+      allowedRelationship: allowedRelationshipString,
       token_chunk_size,
       chunk_overlap,
       chunks_to_combine,
@@ -98,7 +99,7 @@ export const extractAPI = async (
       source_type,
       file_name,
       allowedNodes,
-      allowedRelationship,
+      allowedRelationship: allowedRelationshipString,
       token_chunk_size,
       chunk_overlap,
       chunks_to_combine,
@@ -112,7 +113,7 @@ export const extractAPI = async (
       source_type,
       file_name,
       allowedNodes,
-      allowedRelationship,
+      allowedRelationship: allowedRelationshipString,
       token_chunk_size,
       chunk_overlap,
       chunks_to_combine,
@@ -125,7 +126,7 @@ export const extractAPI = async (
       source_type,
       file_name,
       allowedNodes,
-      allowedRelationship,
+      allowedRelationship: allowedRelationshipString,
       token_chunk_size,
       chunk_overlap,
       chunks_to_combine,

--- a/frontend/src/utils/FileAPI.ts
+++ b/frontend/src/utils/FileAPI.ts
@@ -30,7 +30,7 @@ export const extractAPI = async (
   gcs_bucket_name?: string,
   gcs_bucket_folder?: string,
   allowedNodes?: string[],
-  allowedRelationship?: string[],
+  allowedRelationship?: string[] | [string, string, string][],
   token_chunk_size?: number,
   chunk_overlap?: number,
   chunks_to_combine?: number,


### PR DESCRIPTION
This pull request enhances our graph schema definition by introducing support for a **three-tuple approach to relationship extraction**. In this approach, each relationship is represented as a tuple containing three elements: the **source node**, the **relationship type**, and the **target node**. This structure improves clarity, consistency, and precision when modeling relationships within the system.

To ensure compatibility, the new implementation is designed to handle both the current list-based approach and the new three-tuple approach. 

### Key Enhancements:

- **Backward Compatibility:** The system will continue supporting the existing list-based approach.
- **Improved Precision:** The three-tuple format allows for a more structured and explicit representation of relationships.
- **Seamless Frontend-Backend Communication:** Ensures structured relationship data is properly transmitted and parsed using JSON serialization.

This implementation aligns with the methodologies outlined in LangChain's guide on graph construction, particularly the section demonstrating the use of the LLMGraphTransformer for relationship extraction. For more details, please refer to the guide: [LangChain Graph Construction Guide](https://github.com/langchain-ai/langchain/blob/master/docs/docs/how_to/graph_constructing.ipynb)

As an initial step, this PR focuses on establishing a robust backend–frontend connection to support both approaches.