### PR TITLE
Unable to get the status of document node resolved due to leading spaces

### DIFF
--- a/backend/src/document_sources/web_pages.py
+++ b/backend/src/document_sources/web_pages.py
@@ -6,7 +6,7 @@ def get_documents_from_web_page(source_url:str):
   try:
     pages = WebBaseLoader(source_url, verify_ssl=False).load()
     try:
-      file_name = pages[0].metadata['title']
+      file_name = pages[0].metadata['title'].strip()
       if not file_name:
         file_name = last_url_segment(source_url)      
     except:


### PR DESCRIPTION
Resolved web url sources extraction failing for some of the urls due to leading and trailing spaces in document names.