### PR TITLE
Unable to add multiple web pages with the same title

### DIFF
--- a/backend/src/document_sources/web_pages.py
+++ b/backend/src/document_sources/web_pages.py
@@ -5,12 +5,6 @@ from src.shared.common_fn import last_url_segment
 def get_documents_from_web_page(source_url:str):
   try:
     pages = WebBaseLoader(source_url, verify_ssl=False).load()
-    try:
-      file_name = pages[0].metadata['title'].strip()
-      if not file_name:
-        file_name = last_url_segment(source_url)      
-    except:
-      file_name = last_url_segment(source_url)
-    return file_name, pages
+    return pages
   except Exception as e:
     raise LLMGraphBuilderException(str(e))

--- a/backend/src/graphDB_dataAccess.py
+++ b/backend/src/graphDB_dataAccess.py
@@ -564,3 +564,12 @@ class graphDBdataAccess:
         except Exception as e:
             print(f"Error in getting node labels/relationship types from db: {e}")
             return []
+
+    def get_websource_url(self,file_name):
+        logging.info("Checking if same title with different URL exist in db ")
+        query = """
+                MATCH(d:Document {fileName : $file_name}) WHERE d.fileSource = "web-url" 
+                RETURN d.url AS url
+                """
+        param = {"file_name" : file_name}
+        return self.execute_query(query, param)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -124,7 +124,12 @@ def create_source_node_graph_web_url(graph, model, source_url, source_type):
       raise LLMGraphBuilderException(message)
     try:
       title = pages[0].metadata['title'].strip()
-      if not title:
+      if title:
+        graphDb_data_Access = graphDBdataAccess(graph)
+        existing_url = graphDb_data_Access.get_websource_url(title)
+        if existing_url != source_url:
+          title = str(title) + "-" + str(last_url_segment(source_url)).strip()
+      else:
         title = last_url_segment(source_url)
       language = pages[0].metadata['language']
     except:
@@ -253,7 +258,7 @@ async def extract_graph_from_file_s3(uri, userName, password, database, model, s
   
 async def extract_graph_from_web_page(uri, userName, password, database, model, source_url, file_name, allowedNodes, allowedRelationship, token_chunk_size, chunk_overlap, chunks_to_combine, retry_condition, additional_instructions):
   if not retry_condition:
-    file_name, pages = get_documents_from_web_page(source_url)
+    pages = get_documents_from_web_page(source_url)
     if pages==None or len(pages)==0:
       raise LLMGraphBuilderException(f'Content is not available for given URL : {file_name}')
     return await processing_source(uri, userName, password, database, model, file_name, pages, allowedNodes, allowedRelationship, token_chunk_size, chunk_overlap, chunks_to_combine, additional_instructions=additional_instructions)


### PR DESCRIPTION
Fixed the issue  #1105  where different URL having same title in page metadata written as same file in LLM Graph builder.
Now each URL will be treated as different file.

