### PR TITLE
Added pypandoc-binary package for OSError: No pandoc was found.

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -59,3 +59,4 @@ Secweb==1.11.0
 ragas==0.2.11
 rouge_score==0.1.2
 langchain-neo4j==0.3.0
+pypandoc-binary==1.15


### PR DESCRIPTION
Resolved the issue during extraction for docx file
Error 
`OSError: No pandoc was found: either install pandoc and add it
to your PATH or or call pypandoc.download_pandoc(...) or
install pypandoc wheels with included pandoc.`

Added pypandoc-binary in dependencies