### PR TITLE
top entities not found - bug resolved

### DIFF
--- a/backend/src/QA_integration.py
+++ b/backend/src/QA_integration.py
@@ -204,7 +204,7 @@ def format_documents(documents, model):
                 if 'relationshipids' in doc.metadata['entities']:
                     entities.setdefault('relationshipids', set()).update(doc.metadata['entities']['relationshipids'])
             if 'communitydetails' in doc.metadata:
-                existing_ids = {entry['id'] for entry in global_communities}  # Store existing IDs
+                existing_ids = {entry['id'] for entry in global_communities}
                 new_entries = [entry for entry in doc.metadata["communitydetails"] if entry['id'] not in existing_ids]
                 global_communities.extend(new_entries)
 

--- a/backend/src/QA_integration.py
+++ b/backend/src/QA_integration.py
@@ -198,8 +198,15 @@ def format_documents(documents, model):
             source = doc.metadata.get('source', "unknown")
             sources.add(source)
 
-            entities = doc.metadata['entities'] if 'entities'in doc.metadata.keys() else entities
-            global_communities = doc.metadata["communitydetails"] if 'communitydetails'in doc.metadata.keys() else global_communities
+            if 'entities' in doc.metadata:
+                if 'entityids' in doc.metadata['entities']:
+                    entities.setdefault('entityids', set()).update(doc.metadata['entities']['entityids'])
+                if 'relationshipids' in doc.metadata['entities']:
+                    entities.setdefault('relationshipids', set()).update(doc.metadata['entities']['relationshipids'])
+            if 'communitydetails' in doc.metadata:
+                existing_ids = {entry['id'] for entry in global_communities}  # Store existing IDs
+                new_entries = [entry for entry in doc.metadata["communitydetails"] if entry['id'] not in existing_ids]
+                global_communities.extend(new_entries)
 
             formatted_doc = (
                 "Document start\n"


### PR DESCRIPTION
Fixed an issue in chatbot responses where related entities were not appearing as top entities. 
The bug was caused by overwriting entityids, relationshipids, and communitydetails across iterations. 
Now, these values accumulate correctly, ensuring all relevant entities are displayed.