### PR TITLE
Wikipedia additional pages fetching issue

### DIFF
--- a/backend/src/document_sources/wikipedia.py
+++ b/backend/src/document_sources/wikipedia.py
@@ -4,7 +4,7 @@ from src.shared.llm_graph_builder_exception import LLMGraphBuilderException
 
 def get_documents_from_Wikipedia(wiki_query:str, language:str):
   try:
-    pages = WikipediaLoader(query=wiki_query.strip(), lang=language, load_all_available_meta=False).load()
+    pages = WikipediaLoader(query=wiki_query.strip(), lang=language, load_all_available_meta=False,doc_content_chars_max=100000,load_max_docs=1).load()
     file_name = wiki_query.strip()
     logging.info(f"Total Pages from Wikipedia = {len(pages)}") 
     return file_name, pages


### PR DESCRIPTION
Fixed an issue where WikipediaLoader fetches multiple related pages instead of limiting results to the exact requested page. The issue occurs because wikipedia.search() returns multiple related titles, leading to unintended content from linked articles.

Fixed by setting load_max_docs=1