### PR TITLE
Enhancing Schema Definition with UI Graph

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,8 @@
     "react-markdown": "^9.0.1",
     "react-router": "^6.23.1",
     "react-router-dom": "^6.23.1",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "vis-network": "^9.1.9"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.0.7",

--- a/frontend/src/components/Popups/GraphEnhancementDialog/EnititySchemaExtraction/EntitySchemaExtractionSetting.tsx
+++ b/frontend/src/components/Popups/GraphEnhancementDialog/EnititySchemaExtraction/EntitySchemaExtractionSetting.tsx
@@ -296,7 +296,7 @@ export default function EntitySchemaExtractionSetting({
             addEdge: (edgeData: any, callback: any) => {
               // Assign the edge label and properties from the inputs.
               edgeData.label = newEdgeLabelRef.current;
-              edgeData.proprities = newEdgePropertiesRef.current;
+              edgeData.properties = newEdgePropertiesRef.current;
               edgeData.id = nextEdgeIdRef.current++;
               callback(edgeData);
               setNewEdgeLabel('');
@@ -349,7 +349,7 @@ export default function EntitySchemaExtractionSetting({
     if (nodesRef.current) {
       const newId = nextNodeIdRef.current++;
       const label = newNodeLabel.trim() || `Node ${newId}`;
-      nodesRef.current.add({ id: newId, label, proprities: newNodeProperties });
+      nodesRef.current.add({ id: newId, label, properties: newNodeProperties });
       setNewNodeLabel('');
       setNewNodeProperties([]);
     }
@@ -479,8 +479,8 @@ export default function EntitySchemaExtractionSetting({
                   </p>
                   <p>
                     <span className="font-semibold">Properties:</span>{' '}
-                    {selectedElement.data.proprities.length > 0
-                      ? selectedElement.data.proprities.join(', ')
+                    {selectedElement.data.properties.length > 0
+                      ? selectedElement.data.properties.join(', ')
                       : 'None'}
                   </p>
                   <ButtonWithToolTip
@@ -512,8 +512,8 @@ export default function EntitySchemaExtractionSetting({
                   </p>
                   <p>
                     <span className="font-semibold">Properties:</span>{' '}
-                    {selectedElement.data.proprities.length > 0
-                      ? selectedElement.data.proprities.join(', ')
+                    {selectedElement.data.properties.length > 0
+                      ? selectedElement.data.properties.join(', ')
                       : 'None'}
                   </p>
                   <ButtonWithToolTip

--- a/frontend/src/components/Popups/GraphEnhancementDialog/EnititySchemaExtraction/EntitySchemaExtractionSetting.tsx
+++ b/frontend/src/components/Popups/GraphEnhancementDialog/EnititySchemaExtraction/EntitySchemaExtractionSetting.tsx
@@ -1,0 +1,520 @@
+import { MouseEventHandler, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import ButtonWithToolTip from '../../../UI/ButtonWithToolTip';
+import { appLabels, buttonCaptions, getDefaultSchemaExamples, nvlOptions, tooltips } from '../../../../utils/Constants';
+import { Select, Flex, Typography, useMediaQuery, IconButtonArray, TextInput } from '@neo4j-ndl/react';
+import { useCredentials } from '../../../../context/UserCredentials';
+import { useFileContext } from '../../../../context/UsersFiles';
+import { OnChangeValue, ActionMeta } from 'react-select';
+import { BasicNode, BasicRelationship, EntityType, ExtendedNode, ExtendedRelationship, OptionType, schema, SchemaNode, SchemaRelationship, Scheme } from '../../../../types';
+import { getNodeLabelsAndRelTypes } from '../../../../services/GetNodeLabelsRelTypes';
+import { tokens } from '@neo4j-ndl/base';
+import { showNormalToast } from '../../../../utils/toasts';
+import { useHasSelections } from '../../../../hooks/useHasSelections';
+import { ArrowPathIconOutline, FitToScreenIcon, Hierarchy1Icon, MagnifyingGlassMinusIconOutline, MagnifyingGlassPlusIconOutline } from '@neo4j-ndl/react/icons';
+import GraphViewModal from '../../../Graph/GraphViewModal';
+import { InteractiveNvlWrapper } from '@neo4j-nvl/react';
+import { IconButtonWithToolTip } from '../../../UI/IconButtonToolTip';
+import { ResizePanelDetails } from '../../../Graph/ResizePanel';
+import type { Node, NVL, Relationship } from '@neo4j-nvl/base';
+import Legend from '../../../UI/Legend';
+
+
+export default function EntitySchemaExtractionSetting({
+  view,
+  open,
+  onClose,
+  openTextSchema,
+  settingView,
+  onContinue,
+  closeEnhanceGraphSchemaDialog,
+}: {
+  view: 'Dialog' | 'Tabs';
+  open?: boolean;
+  onClose?: () => void;
+  openTextSchema: () => void;
+  settingView: 'contentView' | 'headerView';
+  onContinue?: () => void;
+  closeEnhanceGraphSchemaDialog?: () => void;
+}) {
+  if (!open) {
+    return <></>;
+  }
+  const { setSelectedRels, setSelectedNodes, selectedNodes, selectedRels, selectedSchemas, setSelectedSchemas } =
+    useFileContext();
+  const { userCredentials } = useCredentials();
+  const [loading, setLoading] = useState<boolean>(false);
+  const hasSelections = useHasSelections(selectedNodes, selectedRels);
+  const [openGraphView, setOpenGraphView] = useState<boolean>(false);
+  const [viewPoint, setViewPoint] = useState<string>('tableView');
+  const removeNodesAndRels = (nodelabels: string[], relationshipTypes: string[]) => {
+    const labelsToRemoveSet = new Set(nodelabels);
+    const relationshipLabelsToremoveSet = new Set(relationshipTypes);
+    setSelectedNodes((prevState) => {
+      const filterednodes = prevState.filter((item) => !labelsToRemoveSet.has(item.label));
+      localStorage.setItem(
+        'selectedNodeLabels',
+        JSON.stringify({ db: userCredentials?.uri, selectedOptions: filterednodes })
+      );
+      return filterednodes;
+    });
+    setSelectedRels((prevState) => {
+      const filteredrels = prevState.filter((item) => !relationshipLabelsToremoveSet.has(item.label));
+      localStorage.setItem(
+        'selectedRelationshipLabels',
+        JSON.stringify({ db: userCredentials?.uri, selectedOptions: filteredrels })
+      );
+      return filteredrels;
+    });
+  };
+  const onChangeSchema = (selectedOptions: OnChangeValue<OptionType, true>, actionMeta: ActionMeta<OptionType>) => {
+    if (actionMeta.action === 'remove-value') {
+      const removedSchema: schema = JSON.parse(actionMeta.removedValue.value);
+      const { nodelabels, relationshipTypes } = removedSchema;
+      removeNodesAndRels(nodelabels, relationshipTypes);
+    } else if (actionMeta.action === 'clear') {
+      const removedSchemas = actionMeta.removedValues.map((s) => JSON.parse(s.value));
+      const removedNodelabels = removedSchemas.map((s) => s.nodelabels).flatMap((k) => k);
+      const removedRelations = removedSchemas.map((s) => s.relationshipTypes).flatMap((k) => k);
+      removeNodesAndRels(removedNodelabels, removedRelations);
+    }
+    setSelectedSchemas(selectedOptions);
+    localStorage.setItem(
+      'selectedSchemas',
+      JSON.stringify({ db: userCredentials?.uri, selectedOptions: selectedOptions })
+    );
+    const nodesFromSchema = selectedOptions.map((s) => JSON.parse(s.value).nodelabels).flat();
+    const relationsFromSchema = selectedOptions.map((s) => JSON.parse(s.value).relationshipTypes).flat();
+    let nodeOptionsFromSchema: OptionType[] = [];
+    for (let index = 0; index < nodesFromSchema.length; index++) {
+      const n = nodesFromSchema[index];
+      nodeOptionsFromSchema.push({ label: n, value: n });
+    }
+    let relationshipOptionsFromSchema: OptionType[] = [];
+    for (let index = 0; index < relationsFromSchema.length; index++) {
+      const r = relationsFromSchema[index];
+      relationshipOptionsFromSchema.push({ label: r, value: r });
+    }
+    setSelectedNodes((prev) => {
+      const combinedData = [...prev, ...nodeOptionsFromSchema];
+      const uniqueLabels = new Set();
+      const updatedOptions = combinedData.filter((item) => {
+        if (!uniqueLabels.has(item.label)) {
+          uniqueLabels.add(item.label);
+          return true;
+        }
+        return false;
+      });
+      localStorage.setItem(
+        'selectedNodeLabels',
+        JSON.stringify({ db: userCredentials?.uri, selectedOptions: updatedOptions })
+      );
+      return updatedOptions;
+    });
+    setSelectedRels((prev) => {
+      const combinedData = [...prev, ...relationshipOptionsFromSchema];
+      const uniqueLabels = new Set();
+      const updatedOptions = combinedData.filter((item) => {
+        if (!uniqueLabels.has(item.label)) {
+          uniqueLabels.add(item.label);
+          return true;
+        }
+        return false;
+      });
+      localStorage.setItem(
+        'selectedRelationshipLabels',
+        JSON.stringify({ db: userCredentials?.uri, selectedOptions: updatedOptions })
+      );
+      return updatedOptions;
+    });
+  };
+  const onChangenodes = (selectedOptions: OnChangeValue<OptionType, true>, actionMeta: ActionMeta<OptionType>) => {
+    if (actionMeta.action === 'clear') {
+      localStorage.setItem('selectedNodeLabels', JSON.stringify({ db: userCredentials?.uri, selectedOptions: [] }));
+    }
+    setSelectedNodes(selectedOptions);
+    localStorage.setItem('selectedNodeLabels', JSON.stringify({ db: userCredentials?.uri, selectedOptions }));
+  };
+  const onChangerels = (selectedOptions: OnChangeValue<OptionType, true>, actionMeta: ActionMeta<OptionType>) => {
+    if (actionMeta.action === 'clear') {
+      localStorage.setItem(
+        'selectedRelationshipLabels',
+        JSON.stringify({ db: userCredentials?.uri, selectedOptions: [] })
+      );
+    }
+    setSelectedRels(selectedOptions);
+    localStorage.setItem('selectedRelationshipLabels', JSON.stringify({ db: userCredentials?.uri, selectedOptions }));
+  };
+  const [nodeLabelOptions, setnodeLabelOptions] = useState<OptionType[]>([]);
+  const [relationshipTypeOptions, setrelationshipTypeOptions] = useState<OptionType[]>([]);
+  const defaultExamples = useMemo(() => getDefaultSchemaExamples(), []);
+
+  useEffect(() => {
+    if (userCredentials) {
+      if (open && view === 'Dialog') {
+        const getOptions = async () => {
+          setLoading(true);
+          try {
+            const response = await getNodeLabelsAndRelTypes();
+            setLoading(false);
+            if (response.data.data.length) {
+              const nodelabels = response.data?.data[0]?.labels.map((l) => ({ value: l, label: l }));
+              const reltypes = response.data?.data[0]?.relationshipTypes.map((t) => ({ value: t, label: t }));
+              setnodeLabelOptions(nodelabels);
+              setrelationshipTypeOptions(reltypes);
+            }
+          } catch (error) {
+            setLoading(false);
+            console.log(error);
+          }
+        };
+        getOptions();
+        return;
+      }
+      if (view == 'Tabs') {
+        const getOptions = async () => {
+          setLoading(true);
+          try {
+            const response = await getNodeLabelsAndRelTypes();
+            setLoading(false);
+            if (response.data.data.length) {
+              const nodelabels = response.data?.data[0]?.labels.map((l) => ({ value: l, label: l }));
+              const reltypes = response.data?.data[0]?.relationshipTypes.map((t) => ({ value: t, label: t }));
+              setnodeLabelOptions(nodelabels);
+              setrelationshipTypeOptions(reltypes);
+            }
+          } catch (error) {
+            setLoading(false);
+            console.log(error);
+          }
+        };
+        getOptions();
+      }
+    }
+  }, [userCredentials, open]);
+
+  const clickHandler: MouseEventHandler<HTMLButtonElement> = useCallback(() => {
+    setSelectedSchemas([]);
+    setSelectedNodes(nodeLabelOptions);
+    setSelectedRels(relationshipTypeOptions);
+    localStorage.setItem(
+      'selectedNodeLabels',
+      JSON.stringify({ db: userCredentials?.uri, selectedOptions: nodeLabelOptions })
+    );
+    localStorage.setItem(
+      'selectedRelationshipLabels',
+      JSON.stringify({ db: userCredentials?.uri, selectedOptions: relationshipTypeOptions })
+    );
+  }, [nodeLabelOptions, relationshipTypeOptions]);
+
+  const handleClear = () => {
+    setSelectedNodes([]);
+    setSelectedRels([]);
+    setSelectedSchemas([]);
+    localStorage.setItem('selectedNodeLabels', JSON.stringify({ db: userCredentials?.uri, selectedOptions: [] }));
+    localStorage.setItem(
+      'selectedRelationshipLabels',
+      JSON.stringify({ db: userCredentials?.uri, selectedOptions: [] })
+    );
+    localStorage.setItem('selectedSchemas', JSON.stringify({ db: userCredentials?.uri, selectedOptions: [] }));
+    showNormalToast(`Successfully Removed the Schema settings`);
+    if (view === 'Tabs' && closeEnhanceGraphSchemaDialog != undefined) {
+      closeEnhanceGraphSchemaDialog();
+    }
+  };
+  const handleApply = () => {
+    showNormalToast(`Successfully Applied the Schema settings`);
+    if (view === 'Tabs' && closeEnhanceGraphSchemaDialog != undefined) {
+      closeEnhanceGraphSchemaDialog();
+    }
+    localStorage.setItem(
+      'selectedNodeLabels',
+      JSON.stringify({ db: userCredentials?.uri, selectedOptions: selectedNodes })
+    );
+    localStorage.setItem(
+      'selectedRelationshipLabels',
+      JSON.stringify({ db: userCredentials?.uri, selectedOptions: selectedRels })
+    );
+    localStorage.setItem(
+      'selectedSchemas',
+      JSON.stringify({ db: userCredentials?.uri, selectedOptions: selectedSchemas })
+    );
+  };
+
+  const handleSchemaView = () => {
+    setOpenGraphView(true);
+    setViewPoint('showSchemaView');
+  };
+
+  /*************************************/
+  const [nodes, setNodes] = useState<SchemaNode[]>([]);
+  const [relationships, setRelationships] = useState<SchemaRelationship[]>([]);
+  const nvlRef = useRef<NVL>(null);
+  const [selected, setSelected] = useState<{ type: EntityType; id: string } | undefined>(undefined);
+
+  const [newNodeSchemaType, setNewNodeSchemaType] = useState('');
+
+  const mouseEventCallbacks = {
+    onNodeClick: (clickedNode: Node) => {
+      setSelected({ type: 'node', id: clickedNode.id });
+    },
+    onRelationshipClick: (clickedRelationship: Relationship) => {
+      setSelected({ type: 'relationship', id: clickedRelationship.id });
+    },
+    onCanvasClick: () => {
+      setSelected(undefined);
+    },
+    onPan: true,
+    onZoom: true,
+    onDrag: true,
+  };
+
+  const nvlCallbacks = {
+    onLayoutComputing(isComputing: boolean) {
+      if (!isComputing) {
+        handleZoomToFit();
+      }
+    },
+  };
+
+  const handleZoomToFit = () => {
+    nvlRef.current?.fit(
+      nodes.map((node) => node.id),
+      {}
+    );
+  };
+
+  const handleZoomIn = () => {
+    nvlRef.current?.setZoom(nvlRef.current.getScale() * 1.3);
+  };
+
+  const handleZoomOut = () => {
+    nvlRef.current?.setZoom(nvlRef.current.getScale() * 0.7);
+  };
+
+  const selectedItem = useMemo(() => {
+      if (selected === undefined) {
+        return undefined;
+      }
+      if (selected.type === 'node') {
+        return nodes.find((node) => node.id === selected.id);
+      }
+      return relationships.find((relationship) => relationship.id === selected.id);
+    }, [selected, relationships, nodes]);
+
+    const addNewNodeSchema = () => {
+      if (!newNodeSchemaType && newNodeSchemaType!=="") return;
+      setNodes((prevNodes) => {
+        const exists = prevNodes.some(node => node.labels.includes(newNodeSchemaType));
+        if (exists) return prevNodes;
+
+        const newNode:SchemaNode = {
+          id: newNodeSchemaType,
+          description:"",
+          captionAlign: 'bottom',
+          caption: newNodeSchemaType,
+          labels: [newNodeSchemaType],
+          properties: []
+        }
+        
+        return [...prevNodes, newNode];
+      });
+      setNewNodeSchemaType("")
+    };
+
+    const addNodeSchema = (NodeId: string) => {
+      if (!newNodeSchemaType && newNodeSchemaType == "") return;
+      
+      setNodes((prevNodes) => {
+        return prevNodes.map((node) => {
+          if (node.id === NodeId) {
+            if (node.labels.includes(newNodeSchemaType)) return node;
+            return {
+              ...node,
+              labels: [...node.labels, newNodeSchemaType],
+            };
+          }
+          return node;
+        });
+      });
+      setNewNodeSchemaType("");
+    };
+    
+
+
+   
+
+  return (
+    <div >
+      <div className='flex h-[60vh]'>
+        <div className='bg-palette-neutral-bg-default relative' style={{ width: '100%', flex: '1' }}>
+          <InteractiveNvlWrapper
+            nodes={nodes}
+            rels={relationships}
+            nvlOptions={nvlOptions}
+            ref={nvlRef}
+            mouseEventCallbacks={{ ...mouseEventCallbacks }}
+            interactionOptions={{
+              selectOnClick: true,
+            }}
+            nvlCallbacks={nvlCallbacks}
+          />
+          <IconButtonArray orientation='vertical' isFloating={true} className='absolute bottom-4 right-4'>
+            <IconButtonWithToolTip label='Zoomin' text='Zoom in' onClick={handleZoomIn} placement='left'>
+              <MagnifyingGlassPlusIconOutline className='n-size-token-7' />
+            </IconButtonWithToolTip>
+            <IconButtonWithToolTip label='Zoom out' text='Zoom out' onClick={handleZoomOut} placement='left'>
+              <MagnifyingGlassMinusIconOutline className='n-size-token-7' />
+            </IconButtonWithToolTip>
+            <IconButtonWithToolTip
+              label='Zoom to fit'
+              text='Zoom to fit'
+              onClick={handleZoomToFit}
+              placement='left'
+            >
+              <FitToScreenIcon className='n-size-token-7' />
+            </IconButtonWithToolTip>
+          </IconButtonArray>
+        </div>
+        <ResizePanelDetails open={true}>
+          {selectedItem !== undefined ? (
+            <>
+            <div className='flex gap-2 flex-wrap ml-2'>
+              {selectedItem.labels.map((label) => (
+                <Legend
+                  type="node"
+                  key={label}
+                  title={label}
+                  bgColor={"blue"}
+                  onClick={() => {}}
+                />
+              ))}
+              <>
+                <TextInput
+                  htmlAttributes={{
+                    type: "text",
+                    "aria-label": "node schema type",
+                    placeholder: "Node Schema Type",
+                  }}
+                  value={newNodeSchemaType}
+                  onChange={(e) => {
+                    setNewNodeSchemaType(e.target.value);
+                  }}
+                  isFluid={true}
+                  rightElement={
+                    <ButtonWithToolTip
+                      text={"Add Node Type"}
+                      onClick={() => addNodeSchema(selectedItem.id)}
+                      label="Add Node Type"
+                      >
+                      +
+                    </ButtonWithToolTip>
+                  }
+                />
+              </>
+            </div>
+          </>
+         
+          ) : (
+           <>
+            <TextInput
+              htmlAttributes={{
+                type: 'text',
+                'aria-label': 'node schema type',
+                placeholder: 'Node Schema Type',
+              }}
+              value={newNodeSchemaType}
+              onChange={(e) => {
+                setNewNodeSchemaType(e.target.value);
+              }}
+              isFluid={true}
+            />
+            <ButtonWithToolTip
+              text={"Add Node Type"}
+              onClick={addNewNodeSchema}
+              label='Add Node Type'
+            >
+              Add Node Type
+            </ButtonWithToolTip>
+           </>
+          )}
+        </ResizePanelDetails>
+      </div>
+     
+      <div className='mt-4'>
+        <Flex className='mt-4! mb-2 flex items-center' flexDirection='row' justifyContent='flex-end'>
+          <Flex flexDirection='row' gap='4'>
+            <ButtonWithToolTip
+              loading={loading}
+              text={
+                !nodeLabelOptions.length && !relationshipTypeOptions.length
+                  ? `No Labels Found in the Database`
+                  : tooltips.useExistingSchema
+              }
+              disabled={!nodeLabelOptions.length && !relationshipTypeOptions.length}
+              onClick={clickHandler}
+              label='Use Existing Schema'
+              placement='top'
+            >
+              Load Existing Schema
+            </ButtonWithToolTip>
+            <ButtonWithToolTip
+              label={'Graph Schema'}
+              text={tooltips.visualizeGraph}
+              placement='top'
+              fill='outlined'
+              onClick={handleSchemaView}
+            >
+              <Hierarchy1Icon />
+            </ButtonWithToolTip>
+            <ButtonWithToolTip
+              text={tooltips.createSchema}
+              placement='top'
+              onClick={() => {
+                if (view === 'Dialog' && onClose != undefined) {
+                  onClose();
+                }
+                if (view === 'Tabs' && closeEnhanceGraphSchemaDialog != undefined) {
+                  closeEnhanceGraphSchemaDialog();
+                }
+                openTextSchema();
+              }}
+              label='Get Existing Schema From Text'
+            >
+              Get Schema From Text
+            </ButtonWithToolTip>
+            {settingView === 'contentView' ? (
+              <ButtonWithToolTip
+                text={tooltips.continue}
+                placement='top'
+                onClick={onContinue}
+                label='Continue to extract'
+              >
+                {buttonCaptions.continueSettings}
+              </ButtonWithToolTip>
+            ) : (
+              <ButtonWithToolTip
+                text={tooltips.clearGraphSettings}
+                placement='top'
+                onClick={handleClear}
+                label='Clear Graph Settings'
+                disabled={!hasSelections}
+              >
+                {buttonCaptions.clearSettings}
+              </ButtonWithToolTip>
+            )}
+            <ButtonWithToolTip
+              text={tooltips.applySettings}
+              placement='top'
+              onClick={handleApply}
+              label='Apply Graph Settings'
+              disabled={!hasSelections}
+            >
+              {buttonCaptions.applyGraphSchema}
+            </ButtonWithToolTip>
+          </Flex>
+        </Flex>
+      </div>
+      <GraphViewModal open={openGraphView} setGraphViewOpen={setOpenGraphView} viewPoint={viewPoint} />
+    </div>
+  );
+}

--- a/frontend/src/components/Popups/GraphEnhancementDialog/EnititySchemaExtraction/EntitySchemaExtractionSetting.tsx
+++ b/frontend/src/components/Popups/GraphEnhancementDialog/EnititySchemaExtraction/EntitySchemaExtractionSetting.tsx
@@ -298,7 +298,9 @@ export default function EntitySchemaExtractionSetting({
       if (selected.type === 'node') {
         return nodes.find((node) => node.id === selected.id);
       }
-      return relationships.find((relationship) => relationship.id === selected.id);
+      if (selected.type === 'relationship') {
+        return relationships.find((relationship) => relationship.id === selected.id);
+      }
     }, [selected, relationships, nodes]);
 
     const addNewNodeSchema = () => {

--- a/frontend/src/components/Popups/GraphEnhancementDialog/EnititySchemaExtraction/EntitySchemaExtractionSetting.tsx
+++ b/frontend/src/components/Popups/GraphEnhancementDialog/EnititySchemaExtraction/EntitySchemaExtractionSetting.tsx
@@ -288,7 +288,7 @@ export default function EntitySchemaExtractionSetting({
     localStorage.setItem('selectedNodeLabels', JSON.stringify({ db: userCredentials?.uri, selectedOptions:nodesRef.current.map((n: { label: string; }) => { return {label:n.label,value: n.label}}) }));
   
     setSelectedRels(edgesRef.current.map((rel: { label: string; }) => {return {label: rel.label,value:rel.label}}));
-    localStorage.setItem('selectedRelationshipLabels', JSON.stringify({ db: userCredentials?.uri, selectedOption: edgesRef.current.map((rel: { label: string; }) => {return {label: rel.label,value:rel.label}}) }));
+    localStorage.setItem('selectedRelationshipLabels', JSON.stringify({ db: userCredentials?.uri, selectedOptions: edgesRef.current.map((rel: { label: string; }) => {return {label: rel.label,value:rel.label}}) }));
     
     showNormalToast(`Successfully Applied the Schema settings`);
     if (view === 'Tabs' && closeEnhanceGraphSchemaDialog != undefined) {

--- a/frontend/src/components/Popups/GraphEnhancementDialog/index.tsx
+++ b/frontend/src/components/Popups/GraphEnhancementDialog/index.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import DeletePopUpForOrphanNodes from './DeleteTabForOrphanNodes';
 import deleteOrphanAPI from '../../../services/DeleteOrphanNodes';
 import EntityExtractionSettings from './EnitityExtraction/EntityExtractionSetting';
+import EntitySchemaExtractionSettings from './EnititySchemaExtraction/EntitySchemaExtractionSetting';
 import { useFileContext } from '../../../context/UsersFiles';
 import DeduplicationTab from './Deduplication';
 import { tokens } from '@neo4j-ndl/base';
@@ -72,6 +73,14 @@ export default function GraphEnhancementDialog({ open, onClose }: { open: boolea
                     Entity Extraction Settings
                   </Tabs.Tab>
                   <Tabs.Tab
+                    tabId={5}
+                    htmlAttributes={{
+                      'aria-label': 'Entity Extraction Settings',
+                    }}
+                  >
+                    Entity Schema Extraction Settings
+                  </Tabs.Tab>
+                  <Tabs.Tab
                     tabId={1}
                     htmlAttributes={{
                       'aria-label': 'Additional Instructions',
@@ -109,8 +118,8 @@ export default function GraphEnhancementDialog({ open, onClose }: { open: boolea
           </div>
         </div>
       </Dialog.Header>
-      <Dialog.Content className='flex flex-col n-gap-token- grow w-[90%] mx-auto'>
-        <Tabs.TabPanel className='n-flex n-flex-col n-gap-token-4' value={activeTab} tabId={0}>
+      <Dialog.Content className='flex flex-col n-gap-token- grow w-[100%] mx-auto'>
+      <Tabs.TabPanel className='n-flex n-flex-col n-gap-token-4' value={activeTab} tabId={0}>
           <div className='w-[80%] mx-auto'>
             <EntityExtractionSettings
               view='Tabs'
@@ -119,6 +128,18 @@ export default function GraphEnhancementDialog({ open, onClose }: { open: boolea
               }}
               closeEnhanceGraphSchemaDialog={onClose}
               settingView='headerView'
+            />
+          </div>
+        </Tabs.TabPanel><Tabs.TabPanel className='n-flex n-flex-col n-gap-token-4' value={activeTab} tabId={5}>
+          <div className='w-[100%] mx-auto'>
+            <EntitySchemaExtractionSettings
+              view='Tabs'
+              openTextSchema={() => {
+                setShowTextFromSchemaDialog({ triggeredFrom: 'enhancementtab', show: true });
+              }}
+              closeEnhanceGraphSchemaDialog={onClose}
+              settingView='headerView'
+              open={open}
             />
           </div>
         </Tabs.TabPanel>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -665,7 +665,7 @@ export interface ExtendedNode extends Node {
 export interface NodeSchema {
   id: number;
   label: string;
-  proprities: string[];
+  properties: string[];
 }
 
 export interface RelationshipSchema {
@@ -673,7 +673,7 @@ export interface RelationshipSchema {
   from: number;
   to: number;
   label: string;
-  proprities: string[];
+  properties: string[];
 }
 
 export interface NeoNode {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -662,6 +662,12 @@ export interface ExtendedNode extends Node {
   };
 }
 
+export interface SchemaNode extends Node{
+  description:string;
+  labels: string[];
+  properties:string[];
+}
+
 export interface NeoNode {
   element_id: string;
   labels: string[];
@@ -676,6 +682,10 @@ export interface NeoRelationship {
 
 export interface ExtendedRelationship extends Relationship {
   count?: number;
+}
+export interface SchemaRelationship extends Relationship {
+  labels: string[];
+  properties:string[];
 }
 export interface connectionState {
   openPopUp: boolean;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -662,10 +662,18 @@ export interface ExtendedNode extends Node {
   };
 }
 
-export interface SchemaNode extends Node{
-  description:string;
-  labels: string[];
-  properties:string[];
+export interface NodeSchema {
+  id: number;
+  label: string;
+  proprities: string[];
+}
+
+export interface RelationshipSchema {
+  id: number;
+  from: number;
+  to: number;
+  label: string;
+  proprities: string[];
 }
 
 export interface NeoNode {
@@ -682,10 +690,6 @@ export interface NeoRelationship {
 
 export interface ExtendedRelationship extends Relationship {
   count?: number;
-}
-export interface SchemaRelationship extends Relationship {
-  labels: string[];
-  properties:string[];
 }
 export interface connectionState {
   openPopUp: boolean;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@alloc/quick-lru@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
+  integrity sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==
+
 "@ampproject/remapping@^2.2.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.3.0.tgz#ed441b6fa600072520ce18b43d2c8cc8caecc7f4"
@@ -4069,7 +4074,6 @@ iterator.prototype@^1.1.2:
     reflect.getprototypeof "^1.0.4"
     set-function-name "^2.0.1"
 
-
 jiti@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.4.2.tgz#d19b7732ebb6116b06e2038da74a55366faef560"
@@ -4157,7 +4161,6 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-
 lightningcss-darwin-arm64@1.29.1:
   version "1.29.1"
   resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.1.tgz#dce17349c7b9f968f396ec240503de14e7b4870b"
@@ -4225,6 +4228,7 @@ lightningcss@^1.29.1:
     lightningcss-linux-x64-musl "1.29.1"
     lightningcss-win32-arm64-msvc "1.29.1"
     lightningcss-win32-x64-msvc "1.29.1"
+
 lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
@@ -4695,10 +4699,6 @@ node-releases@^2.0.18:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.18.tgz#f010e8d35e2fe8d6b2944f03f70213ecedc4ca3f"
   integrity sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==
 
-normalize-range@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
-  integrity sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==
 obj-case@0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/obj-case/-/obj-case-0.2.1.tgz#13a554d04e5ca32dfd9d566451fd2b0e11007f1a"
@@ -4863,7 +4863,6 @@ picocolors@^1.0.0, picocolors@^1.0.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.1.tgz#a8ad579b571952f0e5d25892de5445bcfe25aaa1"
   integrity sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==
 
-
 picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
@@ -4883,11 +4882,6 @@ possible-typed-array-names@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz#89bb63c6fada2c3e90adc4a647beeeb39cc7bf8f"
   integrity sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==
-
-postcss-value-parser@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
-  integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
 postcss@^8.4.27, postcss@^8.4.33:
   version "8.4.41"
@@ -5668,18 +5662,16 @@ tabbable@^6.0.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.2.0.tgz#732fb62bc0175cfcec257330be187dcfba1f3b97"
   integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==
-  
+
 tailwindcss@4.0.7, tailwindcss@^4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-4.0.7.tgz#b3e26a5dda77651808a873f1b535cc8c39fcb0ae"
   integrity sha512-yH5bPPyapavo7L+547h3c4jcBXcrKwybQRjwdEIVAd9iXRvy/3T1CC6XSQEgZtRySjKfqvo3Cc0ZF1DTheuIdA==
 
-
 tapable@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
-
 
 text-table@^0.2.0:
   version "0.2.0"
@@ -5974,6 +5966,11 @@ vfile@^6.0.0:
     "@types/unist" "^3.0.0"
     unist-util-stringify-position "^4.0.0"
     vfile-message "^4.0.0"
+
+vis-network@^9.1.9:
+  version "9.1.9"
+  resolved "https://registry.yarnpkg.com/vis-network/-/vis-network-9.1.9.tgz#8159b34e7c1570150fcc9296213d2b88ed169394"
+  integrity sha512-Ft+hLBVyiLstVYSb69Q1OIQeh3FeUxHJn0WdFcq+BFPqs+Vq1ibMi2sb//cxgq1CP7PH4yOXnHxEH/B2VzpZYA==
 
 vite@^4.5.3:
   version "4.5.3"


### PR DESCRIPTION
Hi team,

I’ve been working on a new approach to define the schema using the UI graph. With this update, you now have the option to define the schema using the graph UI alongside the traditional select UI. This enhancement offers greater flexibility by allowing you to:

- Use the existing schema from the database.
- Utilize predefined schemas.
- *(Upcoming)* Adapt the three-tuple relation logic to load data into the graph UI.

This work is related to [[GitHub Issue #1074](https://github.com/neo4j-labs/llm-graph-builder/issues/1074)](https://github.com/neo4j-labs/llm-graph-builder/issues/1074).

I’ve prepared a demo video that walks through the current progress:

https://github.com/user-attachments/assets/3a4c84ee-ab48-496c-aebf-1c375670edcf

I’d appreciate your review and any guidelines or suggestions you might have.

Looking forward to your insights and feedback.

Best regards,  
Dhiaaeddine





