### PR TITLE
data importer with format fixes

### DIFF
--- a/frontend/src/components/Layout/PageLayout.tsx
+++ b/frontend/src/components/Layout/PageLayout.tsx
@@ -523,7 +523,7 @@ const PageLayout: React.FC = () => {
   }, []);
 
   const openDataImporterSchema = useCallback(() => {
-    setShowTextFromSchemaDialog({ triggeredFrom: 'schemadialog', show: true });
+    setDataImporterSchemaDialog({ triggeredFrom: 'schemadialog', show: true });
   }, []);
 
   const openChatBot = useCallback(() => setShowChatBot(true), []);

--- a/frontend/src/components/Layout/PageLayout.tsx
+++ b/frontend/src/components/Layout/PageLayout.tsx
@@ -612,7 +612,7 @@ const PageLayout: React.FC = () => {
         }}
         onApply={handlePredinedApply}
       ></PredefinedSchemaDialog>
-      <DataImporterSchemaDailog
+      <DataImporterSchemaDialog
         open={dataImporterSchemaDialog.show}
         onClose={() => {
           setDataImporterSchemaDialog({ triggeredFrom: '', show: false });
@@ -625,7 +625,7 @@ const PageLayout: React.FC = () => {
           }
         }}
         onApply={handleImporterApply}
-      ></DataImporterSchemaDailog>
+      ></DataImporterSchemaDialog>
       {isLargeDesktop ? (
         <div
           className={`layout-wrapper ${!isLeftExpanded ? 'drawerdropzoneclosed' : ''} ${

--- a/frontend/src/components/Layout/PageLayout.tsx
+++ b/frontend/src/components/Layout/PageLayout.tsx
@@ -23,7 +23,7 @@ import PredefinedSchemaDialog from '../Popups/GraphEnhancementDialog/EnitityExtr
 import { SKIP_AUTH } from '../../utils/Constants';
 import { useNavigate } from 'react-router';
 import { deduplicateByFullPattern, deduplicateNodeByValue } from '../../utils/Utils';
-import DataImporterSchemaDailog from '../Popups/GraphEnhancementDialog/EnitityExtraction/DataImporter';
+import DataImporterSchemaDialog from '../Popups/GraphEnhancementDialog/EnitityExtraction/DataImporter';
 
 const GCSModal = lazy(() => import('../DataSources/GCS/GCSModal'));
 const S3Modal = lazy(() => import('../DataSources/AWS/S3Modal'));

--- a/frontend/src/components/Layout/PageLayout.tsx
+++ b/frontend/src/components/Layout/PageLayout.tsx
@@ -16,7 +16,7 @@ import { envConnectionAPI } from '../../services/ConnectAPI';
 import { healthStatus } from '../../services/HealthStatus';
 import { useAuth0 } from '@auth0/auth0-react';
 import { showErrorToast } from '../../utils/Toasts';
-import { APP_SOURCES, LOCAL_KEYS } from '../../utils/Constants';
+import { APP_SOURCES } from '../../utils/Constants';
 import { createDefaultFormData } from '../../API/Index';
 import LoadDBSchemaDialog from '../Popups/GraphEnhancementDialog/EnitityExtraction/LoadExistingSchema';
 import PredefinedSchemaDialog from '../Popups/GraphEnhancementDialog/EnitityExtraction/PredefinedSchemaDialog';
@@ -187,7 +187,6 @@ const PageLayout: React.FC = () => {
     setSchemaValRels,
     setDbNodes,
     setDbRels,
-    setSchemaView,
     setPreDefinedNodes,
     setPreDefinedRels,
     setPreDefinedPattern,
@@ -199,6 +198,9 @@ const PageLayout: React.FC = () => {
     setImporterPattern,
     setImporterNodes,
     setImporterRels,
+    setSourceOptions,
+    setTargetOptions,
+    setTypeOptions,
   } = useFileContext();
   const navigate = useNavigate();
   const { user, isAuthenticated } = useAuth0();
@@ -386,10 +388,9 @@ const PageLayout: React.FC = () => {
         const combined = [...rels, ...prevRels];
         return deduplicateByFullPattern(combined);
       });
-      setSchemaView('text');
-      localStorage.setItem(LOCAL_KEYS.source, JSON.stringify(updatedSource));
-      localStorage.setItem(LOCAL_KEYS.type, JSON.stringify(updatedType));
-      localStorage.setItem(LOCAL_KEYS.target, JSON.stringify(updatedTarget));
+      setSourceOptions((prev) => [...prev, ...updatedSource]);
+      setTargetOptions((prev) => [...prev, ...updatedTarget]);
+      setTypeOptions((prev) => [...prev, ...updatedType]);
     },
     []
   );
@@ -415,7 +416,6 @@ const PageLayout: React.FC = () => {
         triggeredFrom: 'loadExistingSchemaApply',
         show: true,
       });
-      setSchemaView('db');
       setDbNodes(nodes);
       setCombinedNodesVal((prevNodes: OptionType[]) => {
         const combined = [...nodes, ...prevNodes];
@@ -426,9 +426,9 @@ const PageLayout: React.FC = () => {
         const combined = [...rels, ...prevRels];
         return deduplicateByFullPattern(combined);
       });
-      localStorage.setItem(LOCAL_KEYS.source, JSON.stringify(updatedSource));
-      localStorage.setItem(LOCAL_KEYS.type, JSON.stringify(updatedType));
-      localStorage.setItem(LOCAL_KEYS.target, JSON.stringify(updatedTarget));
+      setSourceOptions((prev) => [...prev, ...updatedSource]);
+      setTargetOptions((prev) => [...prev, ...updatedTarget]);
+      setTypeOptions((prev) => [...prev, ...updatedType]);
     },
     []
   );
@@ -453,7 +453,6 @@ const PageLayout: React.FC = () => {
         triggeredFrom: 'predefinedSchemaApply',
         show: true,
       });
-      setSchemaView('preDefined');
       setPreDefinedNodes(nodes);
       setCombinedNodesVal((prevNodes: OptionType[]) => {
         const combined = [...nodes, ...prevNodes];
@@ -464,9 +463,9 @@ const PageLayout: React.FC = () => {
         const combined = [...rels, ...prevRels];
         return deduplicateByFullPattern(combined);
       });
-      localStorage.setItem(LOCAL_KEYS.source, JSON.stringify(updatedSource));
-      localStorage.setItem(LOCAL_KEYS.type, JSON.stringify(updatedType));
-      localStorage.setItem(LOCAL_KEYS.target, JSON.stringify(updatedTarget));
+      setSourceOptions((prev) => [...prev, ...updatedSource]);
+      setTargetOptions((prev) => [...prev, ...updatedTarget]);
+      setTypeOptions((prev) => [...prev, ...updatedType]);
     },
     []
   );
@@ -492,7 +491,6 @@ const PageLayout: React.FC = () => {
         triggeredFrom: 'importerSchemaApply',
         show: true,
       });
-      setSchemaView('importer');
       setImporterNodes(nodes);
       setCombinedNodesVal((prevNodes: OptionType[]) => {
         const combined = [...nodes, ...prevNodes];
@@ -503,9 +501,9 @@ const PageLayout: React.FC = () => {
         const combined = [...rels, ...prevRels];
         return deduplicateByFullPattern(combined);
       });
-      localStorage.setItem(LOCAL_KEYS.source, JSON.stringify(updatedSource));
-      localStorage.setItem(LOCAL_KEYS.type, JSON.stringify(updatedType));
-      localStorage.setItem(LOCAL_KEYS.target, JSON.stringify(updatedTarget));
+      setSourceOptions((prev) => [...prev, ...updatedSource]);
+      setTargetOptions((prev) => [...prev, ...updatedTarget]);
+      setTypeOptions((prev) => [...prev, ...updatedType]);
     },
     []
   );

--- a/frontend/src/components/Popups/GraphEnhancementDialog/EnitityExtraction/DataImporter.tsx
+++ b/frontend/src/components/Popups/GraphEnhancementDialog/EnitityExtraction/DataImporter.tsx
@@ -1,0 +1,179 @@
+import { Button, Dialog } from '@neo4j-ndl/react';
+import { useState } from 'react';
+import { OptionType, TupleType } from '../../../../types';
+import { extractOptions, updateSourceTargetTypeOptions } from '../../../../utils/Utils';
+import { useFileContext } from '../../../../context/UsersFiles';
+import ImporterInput from './ImporterInput';
+import SchemaViz from '../../../Graph/SchemaViz';
+import PatternContainer from './PatternContainer';
+import UploadJsonData from './UploadJsonData';
+
+interface DataImporterDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onApply: (
+    patterns: string[],
+    nodeLabels: OptionType[],
+    relationshipLabels: OptionType[],
+    updatedSource: OptionType[],
+    updatedTarget: OptionType[],
+    updatedType: OptionType[]
+  ) => void;
+}
+
+const DataImporterSchemaDailog = ({ open, onClose, onApply }: DataImporterDialogProps) => {
+  const {
+    importerPattern,
+    setImporterPattern,
+    importerNodes,
+    setImporterNodes,
+    importerRels,
+    setImporterRels,
+    sourceOptions,
+    setSourceOptions,
+    targetOptions,
+    setTargetOptions,
+    typeOptions,
+    setTypeOptions,
+  } = useFileContext();
+
+  const [openGraphView, setOpenGraphView] = useState<boolean>(false);
+  const [viewPoint, setViewPoint] = useState<string>('');
+  const handleCancel = () => {
+    onClose();
+    setImporterPattern([]);
+    setImporterNodes([]);
+    setImporterRels([]);
+  };
+
+  const handleImporterCheck = async () => {
+    const [newSourceOptions, newTargetOptions, newTypeOptions] = await updateSourceTargetTypeOptions({
+      patterns: importerPattern.map((label) => ({ label, value: label })),
+      currentSourceOptions: sourceOptions,
+      currentTargetOptions: targetOptions,
+      currentTypeOptions: typeOptions,
+      setSourceOptions,
+      setTargetOptions,
+      setTypeOptions,
+    });
+    onApply(importerPattern, importerNodes, importerRels, newSourceOptions, newTargetOptions, newTypeOptions);
+    onClose();
+  };
+
+  const handleRemovePattern = (patternToRemove: string) => {
+    const updatedPatterns = importerPattern.filter((p) => p !== patternToRemove);
+    if (updatedPatterns.length === 0) {
+      setImporterPattern([]);
+      setImporterNodes([]);
+      setImporterRels([]);
+      return;
+    }
+    const updatedTuples: TupleType[] = updatedPatterns
+      .map((item: string) => {
+        const matchResult = item.match(/^(.+?)-\[:([A-Z_]+)\]->(.+)$/);
+        if (matchResult) {
+          const [source, rel, target] = matchResult.slice(1).map((s) => s.trim());
+          return {
+            value: `${source},${rel},${target}`,
+            label: `${source} -[:${rel}]-> ${target}`,
+            source,
+            target,
+            type: rel,
+          };
+        }
+        return null;
+      })
+      .filter(Boolean) as TupleType[];
+    const { nodeLabelOptions, relationshipTypeOptions } = extractOptions(updatedTuples);
+    setImporterPattern(updatedPatterns);
+    setImporterNodes(nodeLabelOptions);
+    setImporterRels(relationshipTypeOptions);
+  };
+
+  const handleSchemaView = () => {
+    setOpenGraphView(true);
+    setViewPoint('showSchemaView');
+  };
+
+  return (
+    <>
+      <Dialog isOpen={open} onClose={handleCancel}>
+        <Dialog.Header>Entity Graph Extraction Settings</Dialog.Header>
+        <Dialog.Content className='n-flex n-flex-col n-gap-token-6 p-6'>
+          <ImporterInput />
+          <UploadJsonData
+            onSchemaExtracted={({ nodeLabels, relationshipTypes, relationshipObjectTypes, nodeObjectTypes }) => {
+              const nodeLabelMap = Object.fromEntries(nodeLabels.map((n) => [n.$id, n.token]));
+              const relTypeMap = Object.fromEntries(relationshipTypes.map((r) => [r.$id, r.token]));
+              const nodeIdToLabel: Record<string, string> = {};
+              nodeObjectTypes.forEach((nodeObj: any) => {
+                const labelRef = nodeObj.labels?.[0]?.$ref;
+                if (labelRef && nodeLabelMap[labelRef.slice(1)]) {
+                  nodeIdToLabel[nodeObj.$id] = nodeLabelMap[labelRef.slice(1)];
+                }
+              });
+
+              const patterns = relationshipObjectTypes.map((relObj) => {
+                const fromId = relObj.from.$ref.slice(1);
+                const toId = relObj.to.$ref.slice(1);
+                const relId = relObj.type.$ref.slice(1);
+                const fromLabel = nodeIdToLabel[fromId] || 'source';
+                const toLabel = nodeIdToLabel[toId] || 'target';
+                const relLabel = relTypeMap[relId] || 'type';
+                const pattern = `${fromLabel} -[:${relLabel}]-> ${toLabel}`;
+                return pattern;
+              });
+
+              const importerTuples = patterns
+                .map((p) => {
+                  const match = p.match(/^(.+?) -\[:(.+?)\]-> (.+)$/);
+                  if (!match) {
+                    return null;
+                  }
+                  const [_, source, type, target] = match;
+                  return {
+                    label: `${source} -[:${type}]-> ${target}`,
+                    value: `${source},${type},${target}`,
+                    source,
+                    target,
+                    type,
+                  };
+                })
+                .filter(Boolean) as TupleType[];
+              const { nodeLabelOptions, relationshipTypeOptions } = extractOptions(importerTuples);
+              setImporterNodes(nodeLabelOptions);
+              setImporterRels(relationshipTypeOptions);
+              setImporterPattern(patterns);
+            }}
+          />
+          <PatternContainer
+            pattern={importerPattern}
+            handleRemove={handleRemovePattern}
+            handleSchemaView={handleSchemaView}
+            nodes={importerNodes}
+            rels={importerRels}
+          />
+          <Dialog.Actions className='n-flex n-justify-end n-gap-token-4 pt-4'>
+            <Button onClick={handleCancel} isDisabled={importerPattern.length === 0}>
+              Cancel
+            </Button>
+            <Button onClick={handleImporterCheck} isDisabled={importerPattern.length === 0}>
+              Apply
+            </Button>
+          </Dialog.Actions>
+        </Dialog.Content>
+      </Dialog>
+      {openGraphView && (
+        <SchemaViz
+          open={openGraphView}
+          setGraphViewOpen={setOpenGraphView}
+          viewPoint={viewPoint}
+          nodeValues={importerNodes ?? []}
+          relationshipValues={importerRels ?? []}
+        />
+      )}
+    </>
+  );
+};
+
+export default DataImporterSchemaDailog;

--- a/frontend/src/components/Popups/GraphEnhancementDialog/EnitityExtraction/DataImporter.tsx
+++ b/frontend/src/components/Popups/GraphEnhancementDialog/EnitityExtraction/DataImporter.tsx
@@ -98,7 +98,7 @@ const DataImporterSchemaDailog = ({ open, onClose, onApply }: DataImporterDialog
   return (
     <>
       <Dialog isOpen={open} onClose={handleCancel}>
-        <Dialog.Header>Entity Graph Extraction Settings</Dialog.Header>
+        <Dialog.Header>JSON Data Graph Extraction Settings</Dialog.Header>
         <Dialog.Content className='n-flex n-flex-col n-gap-token-6 p-6'>
           <ImporterInput />
           <UploadJsonData

--- a/frontend/src/components/Popups/GraphEnhancementDialog/EnitityExtraction/DataImporter.tsx
+++ b/frontend/src/components/Popups/GraphEnhancementDialog/EnitityExtraction/DataImporter.tsx
@@ -21,7 +21,7 @@ interface DataImporterDialogProps {
   ) => void;
 }
 
-const DataImporterSchemaDailog = ({ open, onClose, onApply }: DataImporterDialogProps) => {
+const DataImporterSchemaDialog = ({ open, onClose, onApply }: DataImporterDialogProps) => {
   const {
     importerPattern,
     setImporterPattern,
@@ -176,4 +176,4 @@ const DataImporterSchemaDailog = ({ open, onClose, onApply }: DataImporterDialog
   );
 };
 
-export default DataImporterSchemaDailog;
+export default DataImporterSchemaDialog;

--- a/frontend/src/components/Popups/GraphEnhancementDialog/EnitityExtraction/ImporterInput.tsx
+++ b/frontend/src/components/Popups/GraphEnhancementDialog/EnitityExtraction/ImporterInput.tsx
@@ -1,0 +1,67 @@
+import { useState, useCallback, KeyboardEvent, ChangeEvent, FocusEvent } from 'react';
+import { Box, TextInput, Button } from '@neo4j-ndl/react';
+import { importerValidation } from '../../../../utils/Utils';
+
+const ImporterInput = () => {
+  const [value, setValue] = useState<string>('');
+  const [isValid, setIsValid] = useState<boolean>(false);
+  const [isFocused, setIsFocused] = useState<boolean>(false);
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+    setValue(newValue);
+    setIsValid(importerValidation(newValue));
+  };
+  const handleBlur = () => {
+    setIsFocused(false);
+    setIsValid(importerValidation(value));
+  };
+  const handleFocus = () => {
+    setIsFocused(true);
+  };
+  const handleSubmit = useCallback(() => {
+    if (importerValidation(value)) {
+      window.open(value, '_blank');
+    }
+  }, [value]);
+  const handleCancel = () => {
+    setValue('');
+    setIsValid(false);
+  };
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.code === 'Enter' && isValid) {
+      handleSubmit();
+    }
+  };
+  const isEmpty = value.trim() === '';
+  return (
+    <Box>
+      <div className='w-full inline-block mb-2'>
+        <TextInput
+          htmlAttributes={{
+            onBlur: handleBlur,
+            onFocus: handleFocus,
+            onKeyDown: handleKeyDown,
+            placeholder: 'Enter URL to import...',
+            'aria-label': 'Importer URL Input',
+          }}
+          value={value}
+          label='Import Link'
+          isFluid
+          isRequired
+          onChange={handleChange}
+          errorText={value && !isValid && isFocused ? 'Please enter a valid URL' : ''}
+        />
+      </div>
+      <div className='w-full flex justify-end gap-2'>
+        <Button onClick={handleCancel} isDisabled={isEmpty} size='medium'>
+          Cancel
+        </Button>
+        <Button onClick={handleSubmit} isDisabled={!isValid} size='medium'>
+          Apply
+        </Button>
+      </div>
+    </Box>
+  );
+};
+
+export default ImporterInput;

--- a/frontend/src/components/Popups/GraphEnhancementDialog/EnitityExtraction/ImporterInput.tsx
+++ b/frontend/src/components/Popups/GraphEnhancementDialog/EnitityExtraction/ImporterInput.tsx
@@ -1,67 +1,12 @@
-import { useState, useCallback, KeyboardEvent, ChangeEvent, FocusEvent } from 'react';
-import { Box, TextInput, Button } from '@neo4j-ndl/react';
-import { importerValidation } from '../../../../utils/Utils';
+import { Box, TextLink } from '@neo4j-ndl/react';
 
 const ImporterInput = () => {
-  const [value, setValue] = useState<string>('');
-  const [isValid, setIsValid] = useState<boolean>(false);
-  const [isFocused, setIsFocused] = useState<boolean>(false);
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const newValue = e.target.value;
-    setValue(newValue);
-    setIsValid(importerValidation(newValue));
-  };
-  const handleBlur = () => {
-    setIsFocused(false);
-    setIsValid(importerValidation(value));
-  };
-  const handleFocus = () => {
-    setIsFocused(true);
-  };
-  const handleSubmit = useCallback(() => {
-    if (importerValidation(value)) {
-      window.open(value, '_blank');
-    }
-  }, [value]);
-  const handleCancel = () => {
-    setValue('');
-    setIsValid(false);
-  };
-  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.code === 'Enter' && isValid) {
-      handleSubmit();
-    }
-  };
-  const isEmpty = value.trim() === '';
   return (
-    <Box>
-      <div className='w-full inline-block mb-2'>
-        <TextInput
-          htmlAttributes={{
-            onBlur: handleBlur,
-            onFocus: handleFocus,
-            onKeyDown: handleKeyDown,
-            placeholder: 'Enter URL to import...',
-            'aria-label': 'Importer URL Input',
-          }}
-          value={value}
-          label='Import Link'
-          isFluid
-          isRequired
-          onChange={handleChange}
-          errorText={value && !isValid && isFocused ? 'Please enter a valid URL' : ''}
-        />
-      </div>
-      <div className='w-full flex justify-end gap-2'>
-        <Button onClick={handleCancel} isDisabled={isEmpty} size='medium'>
-          Cancel
-        </Button>
-        <Button onClick={handleSubmit} isDisabled={!isValid} size='medium'>
-          Apply
-        </Button>
-      </div>
+    <Box className='py-2'>
+      <TextLink isExternalLink={true} href='https://console-preview.neo4j.io/tools/import/models' target='_blank'>
+        Aura Data Models
+      </TextLink>
     </Box>
   );
 };
-
 export default ImporterInput;

--- a/frontend/src/components/Popups/GraphEnhancementDialog/EnitityExtraction/LoadExistingSchema.tsx
+++ b/frontend/src/components/Popups/GraphEnhancementDialog/EnitityExtraction/LoadExistingSchema.tsx
@@ -36,6 +36,7 @@ const LoadDBSchemaDialog = ({ open, onClose, onApply }: LoadDBSchemaDialogProps)
   } = useFileContext();
   const [openGraphView, setOpenGraphView] = useState<boolean>(false);
   const [viewPoint, setViewPoint] = useState<string>('');
+  const [message, setMessage] = useState<string>('');
 
   useEffect(() => {
     if (open) {
@@ -48,6 +49,13 @@ const LoadDBSchemaDialog = ({ open, onClose, onApply }: LoadDBSchemaDialogProps)
     try {
       const response = await getNodeLabelsAndRelTypes();
       const schemaData: string[] = response.data.data.triplets;
+      if (!schemaData || schemaData.length === 0) {
+        setDbNodes([]);
+        setDbRels([]);
+        setDbPattern([]);
+        setMessage('No data found');
+        return;
+      }
       const schemaTuples: TupleType[] = schemaData
         .map((item: string) => {
           const matchResult = item.match(/^(.+?)-([A-Z_]+)->(.+)$/);
@@ -142,6 +150,7 @@ const LoadDBSchemaDialog = ({ open, onClose, onApply }: LoadDBSchemaDialogProps)
         onCancel={handleCancel}
         nodes={dbNodes}
         rels={dbRels}
+        message={message}
       />
       {openGraphView && (
         <SchemaViz

--- a/frontend/src/components/Popups/GraphEnhancementDialog/EnitityExtraction/NewEntityExtractionSetting.tsx
+++ b/frontend/src/components/Popups/GraphEnhancementDialog/EnitityExtraction/NewEntityExtractionSetting.tsx
@@ -72,6 +72,10 @@ export default function NewEntityExtractionSetting({
     setPreDefinedRels,
     preDefinedPattern,
     setPreDefinedPattern,
+    setImporterNodes,
+    setImporterRels,
+    setImporterPattern,
+    importerPattern,
   } = useFileContext();
   const { userCredentials } = useCredentials();
   const [openGraphView, setOpenGraphView] = useState<boolean>(false);
@@ -124,6 +128,10 @@ export default function NewEntityExtractionSetting({
     updateLocalStorage(userCredentials!, 'selectedRelationshipLabels', []);
     updateLocalStorage(userCredentials!, 'selectedPattern', []);
     showNormalToast(`Successfully Removed the Schema settings`);
+    // Importer clear
+    setImporterNodes([]);
+    setImporterRels([]);
+    setImporterPattern([]);
   };
 
   const handleFinalApply = (pattern: string[], nodeLables: OptionType[], relationshipLabels: OptionType[]) => {
@@ -237,11 +245,12 @@ export default function NewEntityExtractionSetting({
 
   const handleRemovePattern = (patternToRemove: string) => {
     const match = patternToRemove.match(/(.*?) -\[:(.*?)\]-> (.*)/);
-    if (!match) {
-      return;
+    let source = '';
+    let rel = '';
+    let target = '';
+    if (match) {
+      [source, rel, target] = match.slice(1).map((s) => s.trim());
     }
-    const [, source, type, target] = match.map((s) => s.trim());
-
     if (userDefinedPattern.includes(patternToRemove)) {
       updateStore(userDefinedPattern, patternToRemove, setUserDefinedPattern, setUserDefinedNodes, setUserDefinedRels);
     }
@@ -254,9 +263,30 @@ export default function NewEntityExtractionSetting({
     if (schemaTextPattern.includes(patternToRemove)) {
       updateStore(schemaTextPattern, patternToRemove, setSchemaTextPattern, setSchemaValNodes, setSchemaValRels);
     }
-    setCombinedPatterns((prev) => prev.filter((p) => p !== patternToRemove));
-    setCombinedNodes((prev) => prev.filter((n) => n.value !== source && n.value !== target));
-    setCombinedRels((prev) => prev.filter((r) => r.value !== type));
+    if (importerPattern.includes(patternToRemove)) {
+      updateStore(importerPattern, patternToRemove, setImporterPattern, setImporterNodes, setImporterRels);
+    }
+    const updatedCombinedPatterns = combinedPatterns.filter((p) => p !== patternToRemove);
+    setCombinedPatterns(updatedCombinedPatterns);
+    const updatedTuples: TupleType[] = updatedCombinedPatterns
+      .map((item) => {
+        const parts = item.match(/(.*?) -\[:(.*?)\]-> (.*)/);
+        if (!parts) {
+          return null;
+        }
+        const [src, rel, tgt] = parts.slice(1).map((s) => s.trim());
+        return {
+          value: `${src},${rel},${tgt}`,
+          label: `${src} -[:${rel}]-> ${tgt}`,
+          source: src,
+          target: tgt,
+          type: rel,
+        };
+      })
+      .filter(Boolean) as TupleType[];
+    const { nodeLabelOptions, relationshipTypeOptions } = extractOptions(updatedTuples);
+    setCombinedNodes(nodeLabelOptions);
+    setCombinedRels(relationshipTypeOptions);
     setTupleOptions((prev) => prev.filter((t) => t.label !== patternToRemove));
   };
 

--- a/frontend/src/components/Popups/GraphEnhancementDialog/EnitityExtraction/NewEntityExtractionSetting.tsx
+++ b/frontend/src/components/Popups/GraphEnhancementDialog/EnitityExtraction/NewEntityExtractionSetting.tsx
@@ -33,6 +33,7 @@ export default function NewEntityExtractionSetting({
   setCombinedNodes,
   combinedRels,
   setCombinedRels,
+  openDataImporterSchema,
 }: {
   view: 'Dialog' | 'Tabs';
   open?: boolean;
@@ -49,6 +50,7 @@ export default function NewEntityExtractionSetting({
   setCombinedNodes: Dispatch<SetStateAction<OptionType[]>>;
   combinedRels: OptionType[];
   setCombinedRels: Dispatch<SetStateAction<OptionType[]>>;
+  openDataImporterSchema: () => void;
 }) {
   const {
     setSelectedRels,
@@ -288,6 +290,16 @@ export default function NewEntityExtractionSetting({
     openLoadSchema();
   }, []);
 
+  const onDataImporterSchemaCLick: MouseEventHandler<HTMLButtonElement> = useCallback(async () => {
+    if (view === 'Dialog' && onClose != undefined) {
+      onClose();
+    }
+    if (view === 'Tabs' && closeEnhanceGraphSchemaDialog != undefined) {
+      closeEnhanceGraphSchemaDialog();
+    }
+    openDataImporterSchema();
+  }, []);
+
   return (
     <div>
       <Typography variant='body-medium'>
@@ -362,6 +374,14 @@ export default function NewEntityExtractionSetting({
                   </TooltipWrapper>
                 }
                 onClick={onSchemaFromTextCLick}
+              />
+              <Menu.Item
+                title={
+                  <TooltipWrapper hasButtonWrapper={true} placement='right' tooltip={tooltips.createSchema}>
+                    Data Importer JSON
+                  </TooltipWrapper>
+                }
+                onClick={onDataImporterSchemaCLick}
               />
             </Menu.Items>
           </Menu>

--- a/frontend/src/components/Popups/GraphEnhancementDialog/EnitityExtraction/UploadJsonData.tsx
+++ b/frontend/src/components/Popups/GraphEnhancementDialog/EnitityExtraction/UploadJsonData.tsx
@@ -1,0 +1,104 @@
+import { Dropzone, Flex, Typography } from '@neo4j-ndl/react';
+import { useState } from 'react';
+import { IconButtonWithToolTip } from '../../../UI/IconButtonToolTip';
+import { InformationCircleIconOutline } from '@neo4j-ndl/react/icons';
+import { showErrorToast } from '../../../../utils/Toasts';
+import { buttonCaptions } from '../../../../utils/Constants';
+import Loader from '../../../../utils/Loader';
+
+interface GraphSchema {
+  nodeLabels: any[];
+  relationshipTypes: any[];
+  relationshipObjectTypes: any[];
+  nodeObjectTypes: any[];
+}
+interface UploadJsonDataProps {
+  onSchemaExtracted: (schema: GraphSchema) => void;
+}
+const UploadJsonData = ({ onSchemaExtracted }: UploadJsonDataProps) => {
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const onDropHandler = async (files: Partial<globalThis.File>[]) => {
+    const file = files[0];
+    if (!file) {
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const fileReader = new FileReader();
+      fileReader.onload = (event) => {
+        try {
+          const jsonText = event.target?.result as string;
+          const parsed = JSON.parse(jsonText);
+          const graphSchema = parsed?.dataModel?.graphSchemaRepresentation?.graphSchema;
+          if (
+            graphSchema &&
+            Array.isArray(graphSchema.nodeLabels) &&
+            Array.isArray(graphSchema.relationshipTypes) &&
+            Array.isArray(graphSchema.relationshipObjectTypes) &&
+            Array.isArray(graphSchema.nodeObjectTypes)
+          ) {
+            onSchemaExtracted({
+              nodeLabels: graphSchema.nodeLabels,
+              relationshipTypes: graphSchema.relationshipTypes,
+              relationshipObjectTypes: graphSchema.relationshipObjectTypes,
+              nodeObjectTypes: graphSchema.nodeObjectTypes,
+            });
+          } else {
+            showErrorToast('Invalid graphSchema format');
+          }
+        } catch (err) {
+          console.error(err);
+          showErrorToast('Failed to parse JSON file.');
+        } finally {
+          setIsLoading(false);
+        }
+      };
+      fileReader.readAsText(file as File);
+    } catch (err) {
+      console.error(err);
+      showErrorToast('Error reading file.');
+      setIsLoading(false);
+    }
+  };
+  return (
+    <Dropzone
+      loadingComponent={isLoading && <Loader title='Uploading' />}
+      isTesting={true}
+      className='bg-none! dropzoneContainer'
+      supportedFilesDescription={
+        <Typography variant='body-small'>
+          <Flex>
+            <span>{buttonCaptions.importDropzoneSpan}</span>
+            <div className='align-self-center'>
+              <IconButtonWithToolTip
+                label='Source info'
+                clean
+                text={
+                  <Typography variant='body-small'>
+                    <Flex gap='3' alignItems='flex-start'>
+                      <span>JSON (.json)</span>
+                    </Flex>
+                  </Typography>
+                }
+              >
+                <InformationCircleIconOutline className='w-[22px] h-[22px]' />
+              </IconButtonWithToolTip>
+            </div>
+          </Flex>
+        </Typography>
+      }
+      dropZoneOptions={{
+        accept: {
+          'application/json': ['.json'],
+        },
+        onDrop: onDropHandler,
+        onDropRejected: (e) => {
+          if (e.length) {
+            showErrorToast('Failed To Upload, Unsupported file extension.');
+          }
+        },
+      }}
+    />
+  );
+};
+export default UploadJsonData;

--- a/frontend/src/components/Popups/GraphEnhancementDialog/index.tsx
+++ b/frontend/src/components/Popups/GraphEnhancementDialog/index.tsx
@@ -50,6 +50,7 @@ export default function GraphEnhancementDialog({
     setPreDefinedPattern,
     setSelectedPreDefOption,
     allPatterns,
+    setDataImporterSchemaDialog,
   } = useFileContext();
   const isTablet = useMediaQuery(`(min-width:${breakpoints.xs}) and (max-width: ${breakpoints.lg})`);
 
@@ -193,6 +194,9 @@ export default function GraphEnhancementDialog({
               setCombinedNodes={setCombinedNodes}
               combinedRels={combinedRels}
               setCombinedRels={setCombinedRels}
+              openDataImporterSchema={() => {
+                setDataImporterSchemaDialog({ triggeredFrom: 'enhancementtab', show: true });
+              }}
             />
           </div>
         </Tabs.TabPanel>

--- a/frontend/src/components/Popups/GraphEnhancementDialog/index.tsx
+++ b/frontend/src/components/Popups/GraphEnhancementDialog/index.tsx
@@ -51,6 +51,9 @@ export default function GraphEnhancementDialog({
     setSelectedPreDefOption,
     allPatterns,
     setDataImporterSchemaDialog,
+    setImporterNodes,
+    setImporterPattern,
+    setImporterRels,
   } = useFileContext();
   const isTablet = useMediaQuery(`(min-width:${breakpoints.xs}) and (max-width: ${breakpoints.lg})`);
 
@@ -86,7 +89,14 @@ export default function GraphEnhancementDialog({
     setPreDefinedNodes([]);
     setPreDefinedRels([]);
     setPreDefinedPattern([]);
+    // combined Nodes and rels
+    setCombinedNodes([]);
+    setCombinedRels([]);
     setCombinedPatterns([]);
+    // Data Importer
+    setImporterNodes([]);
+    setImporterPattern([]);
+    setImporterRels([]);
     setSelectedPreDefOption(null);
     onClose();
   };

--- a/frontend/src/components/UI/SchemaSelectionPopup.tsx
+++ b/frontend/src/components/UI/SchemaSelectionPopup.tsx
@@ -1,4 +1,4 @@
-import { Dialog, Button, LoadingSpinner } from '@neo4j-ndl/react';
+import { Dialog, Button, LoadingSpinner, Typography } from '@neo4j-ndl/react';
 import PatternContainer from '../Popups/GraphEnhancementDialog/EnitityExtraction/PatternContainer';
 import { SchemaSelectionProps } from '../../types';
 
@@ -14,6 +14,7 @@ const SchemaSelectionDialog = ({
   highlightPattern,
   onApply,
   onCancel,
+  message,
 }: SchemaSelectionProps) => {
   return (
     <Dialog size='medium' isOpen={open} onClose={onClose} htmlAttributes={{ 'aria-labelledby': 'form-dialog-title' }}>
@@ -23,17 +24,19 @@ const SchemaSelectionDialog = ({
           <div className='my-40 flex! items-center justify-center'>
             <LoadingSpinner size='large' />
           </div>
+        ) : pattern.length !== 0 ? (
+          <PatternContainer
+            pattern={pattern}
+            handleRemove={handleRemove}
+            handleSchemaView={handleSchemaView}
+            highlightPattern={highlightPattern ?? ''}
+            nodes={nodes}
+            rels={rels}
+          ></PatternContainer>
         ) : (
-          pattern.length !== 0 && (
-            <PatternContainer
-              pattern={pattern}
-              handleRemove={handleRemove}
-              handleSchemaView={handleSchemaView}
-              highlightPattern={highlightPattern ?? ''}
-              nodes={nodes}
-              rels={rels}
-            ></PatternContainer>
-          )
+          <div className='my-40 flex! items-center justify-center'>
+            <Typography variant='body-medium'>{message}</Typography>
+          </div>
         )}
         <Dialog.Actions className='mt-3'>
           <Button onClick={onCancel} isDisabled={pattern.length === 0 || loading}>

--- a/frontend/src/context/UsersFiles.tsx
+++ b/frontend/src/context/UsersFiles.tsx
@@ -17,9 +17,6 @@ import {
   chunkOverlap,
   chunksToCombine,
   tokenchunkSize,
-  sourceOptions as initialSourceOptions,
-  targetOptions as initialTargetOptions,
-  typeOptions as initialTypeOptions,
 } from '../utils/Constants';
 import { useCredentials } from './UserCredentials';
 import Queue from '../utils/Queue';
@@ -92,16 +89,15 @@ const FileContextProvider: FC<FileContextProviderProps> = ({ children }) => {
   const [schemaValRels, setSchemaValRels] = useState<OptionType[]>([]);
   const [dbNodes, setDbNodes] = useState<OptionType[]>([]);
   const [dbRels, setDbRels] = useState<OptionType[]>([]);
-  const [schemaView, setSchemaView] = useState<string | string[]>('');
   const [preDefinedNodes, setPreDefinedNodes] = useState<OptionType[]>([]);
   const [preDefinedRels, setPreDefinedRels] = useState<OptionType[]>([]);
   const [userDefinedNodes, setUserDefinedNodes] = useState<OptionType[]>([]);
   const [userDefinedRels, setUserDefinedRels] = useState<OptionType[]>([]);
   const [preDefinedPattern, setPreDefinedPattern] = useState<string[]>([]);
   const [selectedPreDefOption, setSelectedPreDefOption] = useState<OptionType | null>(null);
-  const [sourceOptions, setSourceOptions] = useState<OptionType[]>(initialSourceOptions);
-  const [typeOptions, setTypeOptions] = useState<OptionType[]>(initialTypeOptions);
-  const [targetOptions, setTargetOptions] = useState<OptionType[]>(initialTargetOptions);
+  const [sourceOptions, setSourceOptions] = useState<OptionType[]>([]);
+  const [typeOptions, setTypeOptions] = useState<OptionType[]>([]);
+  const [targetOptions, setTargetOptions] = useState<OptionType[]>([]);
 
   // Importer schema
   const [importerNodes, setImporterNodes] = useState<OptionType[]>([]);
@@ -115,16 +111,22 @@ const FileContextProvider: FC<FileContextProviderProps> = ({ children }) => {
         setSelectedNodes(selectedNodeLabel.selectedOptions);
       }
     }
-    if (selectedPatternsStr != null) {
-      const selectedPatternLabel = JSON.parse(selectedPatternsStr);
-      if (userCredentials?.uri === selectedPatternLabel.db) {
-        setAllPatterns(selectedPatternLabel.selectedOptions);
+    if (selectedNodeRelsstr != null) {
+      const selectedNodeRels = JSON.parse(selectedNodeRelsstr);
+      if (userCredentials?.uri === selectedNodeRels.db) {
+        setSelectedRels(selectedNodeRels.selectedOptions);
       }
     }
     if (selectedNodeRelsstr != null) {
       const selectedNodeRels = JSON.parse(selectedNodeRelsstr);
       if (userCredentials?.uri === selectedNodeRels.db) {
-        setSelectedRels(selectedNodeRels.selectedOptions);
+        const rels = selectedNodeRels.selectedOptions;
+        setSelectedRels(rels);
+        const generatedPatterns = rels.map((rel: { value: string }) => {
+          const [source, type, target] = rel.value.split(',');
+          return `(${source})-[${type}]->(${target})`;
+        });
+        setAllPatterns(generatedPatterns);
       }
     }
     if (selectedTokenChunkSizeStr != null) {
@@ -208,8 +210,6 @@ const FileContextProvider: FC<FileContextProviderProps> = ({ children }) => {
     setPreDefinedRels,
     preDefinedPattern,
     setPreDefinedPattern,
-    schemaView,
-    setSchemaView,
     userDefinedNodes,
     setUserDefinedNodes,
     userDefinedRels,

--- a/frontend/src/context/UsersFiles.tsx
+++ b/frontend/src/context/UsersFiles.tsx
@@ -7,6 +7,7 @@ import {
   showTextFromSchemaDialogType,
   schemaLoadDialogType,
   predefinedSchemaDialogType,
+  dataImporterSchemaDialogType,
 } from '../types';
 import {
   chatModeLables,
@@ -69,6 +70,11 @@ const FileContextProvider: FC<FileContextProviderProps> = ({ children }) => {
     show: false,
   });
 
+  const [dataImporterSchemaDialog, setDataImporterSchemaDialog] = useState<dataImporterSchemaDialogType>({
+    triggeredFrom: '',
+    show: false,
+  });
+
   const [postProcessingTasks, setPostProcessingTasks] = useState<string[]>([
     'materialize_text_chunk_similarities',
     'enable_hybrid_search_and_fulltext_search_in_bloom',
@@ -96,6 +102,11 @@ const FileContextProvider: FC<FileContextProviderProps> = ({ children }) => {
   const [sourceOptions, setSourceOptions] = useState<OptionType[]>(initialSourceOptions);
   const [typeOptions, setTypeOptions] = useState<OptionType[]>(initialTypeOptions);
   const [targetOptions, setTargetOptions] = useState<OptionType[]>(initialTargetOptions);
+
+  // Importer schema
+  const [importerNodes, setImporterNodes] = useState<OptionType[]>([]);
+  const [importerRels, setImporterRels] = useState<OptionType[]>([]);
+  const [importerPattern, setImporterPattern] = useState<string[]>([]);
 
   useEffect(() => {
     if (selectedNodeLabelstr != null) {
@@ -213,6 +224,14 @@ const FileContextProvider: FC<FileContextProviderProps> = ({ children }) => {
     setTypeOptions,
     targetOptions,
     setTargetOptions,
+    dataImporterSchemaDialog,
+    setDataImporterSchemaDialog,
+    importerNodes,
+    setImporterNodes,
+    importerRels,
+    setImporterRels,
+    importerPattern,
+    setImporterPattern,
   };
   return <FileContext.Provider value={value}>{children}</FileContext.Provider>;
 };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -165,6 +165,7 @@ export interface ContentProps {
   setCombinedNodes: Dispatch<SetStateAction<OptionType[]>>;
   combinedRels: OptionType[];
   setCombinedRels: Dispatch<SetStateAction<OptionType[]>>;
+  openDataImporterSchema: () => void;
 }
 
 export interface FileTableProps {
@@ -870,6 +871,12 @@ export interface predefinedSchemaDialogType {
   onApply?: (selectedPattern: string[], nodes: OptionType[], rels: OptionType[]) => void;
 }
 
+export interface dataImporterSchemaDialogType {
+  triggeredFrom: string;
+  show: boolean;
+  onApply?: (selectedPattern: string[], nodes: OptionType[], rels: OptionType[]) => void;
+}
+
 export interface FileContextType {
   files: (File | null)[] | [];
   filesData: CustomFile[] | [];
@@ -956,6 +963,16 @@ export interface FileContextType {
   setTypeOptions: Dispatch<SetStateAction<OptionType[]>>;
   targetOptions: OptionType[];
   setTargetOptions: Dispatch<SetStateAction<OptionType[]>>;
+
+  // importer defined schema
+  dataImporterSchemaDialog: dataImporterSchemaDialogType;
+  setDataImporterSchemaDialog: React.Dispatch<React.SetStateAction<dataImporterSchemaDialogType>>;
+  importerNodes: OptionType[];
+  setImporterNodes: Dispatch<SetStateAction<OptionType[]>>;
+  importerRels: OptionType[];
+  setImporterRels: Dispatch<SetStateAction<OptionType[]>>;
+  importerPattern: string[];
+  setImporterPattern: Dispatch<SetStateAction<string[]>>;
 }
 export declare type Side = 'top' | 'right' | 'bottom' | 'left';
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -898,8 +898,6 @@ export interface FileContextType {
   setSelectedRows: React.Dispatch<React.SetStateAction<string[]>>;
   chatModes: string[];
   setchatModes: Dispatch<SetStateAction<string[]>>;
-  schemaView: string | string[];
-  setSchemaView: Dispatch<SetStateAction<string | string[]>>;
   postProcessingTasks: string[];
   setPostProcessingTasks: React.Dispatch<React.SetStateAction<string[]>>;
   queue: Queue<CustomFile>;
@@ -1114,4 +1112,5 @@ export interface SchemaSelectionProps {
   onApply: () => void;
   onCancel: () => void;
   view?: string;
+  message?: string;
 }

--- a/frontend/src/utils/Constants.ts
+++ b/frontend/src/utils/Constants.ts
@@ -188,6 +188,7 @@ export const tooltips = {
   visualizeGraph: 'Visualize Graph Schema',
   additionalInstructions: 'Analyze instructions for schema',
   predinedSchema: 'Predefined Schema',
+  dataImporterJson: 'Data Importer JSON',
 };
 export const PRODMODLES = ['openai_gpt_4o', 'openai_gpt_4o_mini', 'diffbot', 'gemini_1.5_flash'];
 export const buttonCaptions = {
@@ -215,6 +216,7 @@ export const buttonCaptions = {
   provideAdditionalInstructions: 'Provide Additional Instructions for Entity Extractions',
   analyzeInstructions: 'Analyze Instructions',
   helpInstructions: 'Provide specific instructions for entity extraction, such as focusing on the key topics.',
+  importDropzoneSpan: 'JSON Documents',
 };
 
 export const POST_PROCESSING_JOBS: { title: string; description: string }[] = [
@@ -372,6 +374,7 @@ export const appLabels = {
   chunkingConfiguration: 'Select a Chunking Configuration',
   graphPatternTuple: 'Graph Pattern',
   selectedPatterns: 'Selected Patterns',
+  dataImporterSchema: 'Schema from Data Importer',
 };
 
 export const LLMDropdownLabel = {

--- a/frontend/src/utils/Utils.ts
+++ b/frontend/src/utils/Utils.ts
@@ -892,3 +892,7 @@ export const deduplicateByFullPattern = (arrays: { value: string; label: string 
   });
   return result;
 };
+
+export const importerValidation = (url: string) => {
+  return url.trim() !== '' && /^https:\/\/console-preview\.neo4j\.io\/tools\/import\/models(\/.*)?$/i.test(url);
+};


### PR DESCRIPTION
This PR adds a new importer option to handle graph schema data from JSON files. Key changes include:

Implementation of URL validation for the new importer in Utils.ts.
Addition of new constants, types, and state management properties for data importer functionality.
Integration of UI components for importing JSON data and updating graph schema settings.

![image](https://github.com/user-attachments/assets/4a625efe-7958-45ed-b869-10524a091919)
