### PR TITLE
Fix backend installation instruction in README.md

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -16,9 +16,14 @@ Follow these steps to set up and run the project locally:
 
 > cd llm-graph-builder
 
-2. Install Dependency :
+2. Create venv and activate it
 
-> pip install -t requirements.txt
+> python -m venv .venv
+> source .venv/bin/activate
+
+3. Install Dependencies :
+
+> pip install -r requirements.txt
 
 ## Run backend project using unicorn
 Run the server:


### PR DESCRIPTION
1) Added instruction to create virtual env
2) Fixed typo in installation command `-t` -> `-r`