### PR TITLE
fix: Add universal ARM64/x86_64 support for torch dependencies

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,11 +18,22 @@ RUN apt-get update && \
    apt-get clean && \
    rm -rf /var/lib/apt/lists/*
 
-# Set LD_LIBRARY_PATH
-ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+# Set LD_LIBRARY_PATH dynamically based on architecture
+# x86_64 uses /usr/lib/x86_64-linux-gnu, ARM64 uses /usr/lib/aarch64-linux-gnu
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        LIB_PATH="/usr/lib/x86_64-linux-gnu"; \
+    elif [ "$ARCH" = "aarch64" ]; then \
+        LIB_PATH="/usr/lib/aarch64-linux-gnu"; \
+    else \
+        LIB_PATH="/usr/lib"; \
+    fi && \
+    echo "LD_LIBRARY_PATH=$LIB_PATH:\$LD_LIBRARY_PATH" >> /etc/environment
+ENV LD_LIBRARY_PATH="/usr/lib"
+
 # Copy requirements file and install Python dependencies
 COPY requirements.txt constraints.txt /code/
-# --no-cache-dir --upgrade 
+# --no-cache-dir --upgrade
 RUN pip install --upgrade pip
 RUN pip install -r requirements.txt -c constraints.txt
 

--- a/backend/constraints.txt
+++ b/backend/constraints.txt
@@ -1,4 +1,6 @@
--f https://download.pytorch.org/whl/torch_stable.html 
-torch==2.3.1+cpu
-torchvision==0.18.1+cpu
-torchaudio==2.3.1+cpu
+# Universal constraints - works on both x86_64 and ARM64 (Apple Silicon)
+# The +cpu suffix is only available for x86_64, so we use version ranges instead
+# For ARM Macs, regular torch packages are CPU-only by default (no CUDA on ARM)
+torch>=2.3.0,<3.0.0
+torchvision>=0.18.0,<1.0.0
+torchaudio>=2.3.0,<3.0.0


### PR DESCRIPTION
## Summary
- Remove x86-only `+cpu` suffix from torch constraints
- Use version ranges instead of pinned `+cpu` versions  
- Fix Dockerfile `LD_LIBRARY_PATH` to detect architecture dynamically
- Enables Docker builds on Apple Silicon (M1/M2/M3) Macs

## Problem
The current `constraints.txt` pins torch to `torch==2.3.1+cpu` which is only available for x86_64 architecture. This causes Docker build failures on ARM64 systems (Apple Silicon Macs).

## Solution
Replace pinned `+cpu` versions with version ranges:
```
torch>=2.3.0,<3.0.0
torchvision>=0.18.0,<1.0.0
torchaudio>=2.3.0,<3.0.0
```

The regular torch packages work on both architectures - ARM Macs use CPU-only builds by default anyway (no CUDA support).

## Test plan
- [ ] Build Docker image on x86_64 Linux
- [ ] Build Docker image on ARM64 (Apple Silicon Mac)
- [ ] Verify backend starts successfully on both architectures

🤖 Generated with [Claude Code](https://claude.com/claude-code)