### PR TITLE
Add a team contact option when token limit is exhausted (#1457)

### DIFF
--- a/frontend/src/components/User/Profile.tsx
+++ b/frontend/src/components/User/Profile.tsx
@@ -110,8 +110,34 @@ export default function Profile() {
       },
     ];
 
+    const exhausted =
+      !isNeo4j &&
+      !isLoadingTokens &&
+      !tokenError &&
+      Boolean(tokenLimits) &&
+      ((Number.isFinite(tokenLimits?.daily_limit) &&
+        Number.isFinite(tokenLimits?.daily_used) &&
+        (tokenLimits!.daily_limit as number) > 0 &&
+        (tokenLimits!.daily_used as number) >= (tokenLimits!.daily_limit as number)) ||
+        (Number.isFinite(tokenLimits?.monthly_limit) &&
+          Number.isFinite(tokenLimits?.monthly_used) &&
+          (tokenLimits!.monthly_limit as number) > 0 &&
+          (tokenLimits!.monthly_used as number) >= (tokenLimits!.monthly_limit as number)));
+
+    const items = [...tokenItems];
+
+    if (exhausted) {
+      items.push({
+        title: 'Request for token limit',
+        onClick: () => {
+          window.open('mailto:llm-graph-builder@neo4j.com', '_blank');
+        },
+        disabled: false,
+      });
+    }
+
     return [
-      ...tokenItems,
+      ...items,
       {
         title: 'Logout',
         onClick: () => {
@@ -128,9 +154,10 @@ export default function Profile() {
           }
           logout({ logoutParams: { returnTo: `${window.location.origin}/readonly` } });
         },
+        disabled: false,
       },
     ];
-  }, [tokenLimits, isLoadingTokens, tokenError, fetchTokenLimits, logout, user?.email]);
+  }, [tokenLimits, isLoadingTokens, tokenError, fetchTokenLimits, logout, user?.email, connectionStatus]);
 
   const handleClick = () => {
     setShowOpen(true);


### PR DESCRIPTION
**This PR adds a menu item in the Profile dropdown to help users request a higher token limit when their daily or monthly usage is exhausted.**
When the condition is met, users will see **Request for token limit** which opens the default mail client to mailto: **llm-graph-builder@neo4j.com.**

- Only appears when limits are actually exhausted for non-neo4j users.
<img width="1917" height="919" alt="image" src="https://github.com/user-attachments/assets/acec4427-91ef-4154-a62d-6983a9311185" />
