### PR TITLE
Gate “Connect to Neo4j” behind authentication (disable + tooltip)

### DIFF
--- a/frontend/src/components/Content.tsx
+++ b/frontend/src/components/Content.tsx
@@ -29,6 +29,7 @@ import {
   tokenchunkSize,
   chunkOverlap,
   chunksToCombine,
+  SKIP_AUTH,
 } from '../utils/Constants';
 import ButtonWithToolTip from './UI/ButtonWithToolTip';
 import DropdownComponent from './Dropdown';
@@ -134,6 +135,7 @@ const Content: React.FC<ContentProps> = ({
   const [deleteLoading, setIsDeleteLoading] = useState<boolean>(false);
 
   const hasSelections = useHasSelections(selectedNodes, selectedRels);
+  const connectDisabled = !isAuthenticated && !SKIP_AUTH;
 
   const { updateStatusForLargeFiles } = useServerSideEvent(
     (inMinutes, time, fileName) => {
@@ -970,19 +972,18 @@ const Content: React.FC<ContentProps> = ({
               Graph Settings
             </ButtonWithToolTip>
             {!connectionStatus ? (
-              <SpotlightTarget
-                id='connectbutton'
-                hasPulse={true}
-                indicatorVariant='border'
-                className='n-bg-palette-primary-bg-strong hover:n-bg-palette-primary-hover-strong'
-              >
-                <Button
+              <SpotlightTarget id='connectbutton' hasPulse={!connectDisabled} indicatorVariant='border'>
+                <ButtonWithToolTip
+                  text={connectDisabled ? 'Please login first to connect' : buttonCaptions.connectToNeo4j}
+                  label={buttonCaptions.connectToNeo4j}
+                  disabled={connectDisabled}
                   size={isTablet ? 'small' : 'medium'}
                   className='mr-2!'
                   onClick={() => setOpenConnection((prev) => ({ ...prev, openPopUp: true }))}
+                  alwaysShowTooltip={true}
                 >
                   {buttonCaptions.connectToNeo4j}
-                </Button>
+                </ButtonWithToolTip>
               </SpotlightTarget>
             ) : (
               showDisconnectButton && (

--- a/frontend/src/components/UI/ButtonWithToolTip.tsx
+++ b/frontend/src/components/UI/ButtonWithToolTip.tsx
@@ -14,6 +14,7 @@ const ButtonWithToolTip = ({
   fill = 'filled',
   type = 'button',
   color,
+  alwaysShowTooltip = false,
 }: {
   text: string | React.ReactNode;
   children: React.ReactNode;
@@ -29,6 +30,7 @@ const ButtonWithToolTip = ({
   fill?: 'filled' | 'outlined' | 'text';
   type?: 'submit' | 'button' | 'reset';
   color?: 'primary' | 'danger' | undefined;
+  alwaysShowTooltip?: boolean;
 }) => {
   const [isHovered, setIsHovered] = useState<boolean>(false);
   return (
@@ -52,7 +54,9 @@ const ButtonWithToolTip = ({
           {children}
         </Button>
       </Tooltip.Trigger>
-      {isHovered && <Tooltip.Content style={{ whiteSpace: 'nowrap' }}>{text}</Tooltip.Content>}
+      {(isHovered || (disabled && alwaysShowTooltip)) && (
+        <Tooltip.Content style={{ whiteSpace: 'nowrap' }}>{text}</Tooltip.Content>
+      )}
     </Tooltip>
   );
 };


### PR DESCRIPTION
[ #1488 ]  This PR disables the **Connect to Neo4j** button when the user is not logged in and shows a tooltip prompting the user to log in.
When authenticated (or when **SKIP_AUTH** is true), the button behaves normally and opens the connection popup.

<img width="1332" height="912" alt="image" src="https://github.com/user-attachments/assets/a935c242-cf92-46ef-9940-238355784298" />
