### PR TITLE
fix: handle wildcard graph privilege in check_account_access

### DIFF
--- a/backend/src/graphDB_dataAccess.py
+++ b/backend/src/graphDB_dataAccess.py
@@ -180,9 +180,9 @@ class graphDBdataAccess:
 
             if edition == "enterprise":
                 write_query = """
-                SHOW USER PRIVILEGES 
+                SHOW USER PRIVILEGES
                 YIELD action, graph
-                WHERE graph = $database AND action = 'write'
+                WHERE (graph = $database OR graph = '*') AND action = 'write'
                 RETURN COUNT(*) AS writeAccessCount
                 """
                 logging.info(f"Checking write access for database: {database}")


### PR DESCRIPTION
Enterprise Neo4j allows granting WRITE on graph '*' (all graphs). The previous query matched only exact graph name, so admin users with 'GRANT WRITE ON GRAPH * TO admin' were reported as read-only.

Add OR graph = '*' condition to the SHOW USER PRIVILEGES query so wildcard grants are recognised as valid write access.