### PR TITLE
Fix Claude 4.7 Opus temperature handling

### DIFF
--- a/backend/src/llm.py
+++ b/backend/src/llm.py
@@ -85,9 +85,15 @@ def get_llm(model: str):
 
         elif "ANTHROPIC" in model:
             model_name, api_key = env_value.split(",")
-            llm = ChatAnthropic(
-                api_key=api_key, model=model_name, temperature=0, timeout=None,callbacks=callback_manager, 
-            )
+            anthropic_kwargs = {
+                "api_key": api_key,
+                "model": model_name,
+                "timeout": None,
+                "callbacks": callback_manager,
+            }
+            if not model_name.startswith("claude-opus-4-7"):
+                anthropic_kwargs["temperature"] = 0
+            llm = ChatAnthropic(**anthropic_kwargs)
 
         elif "FIREWORKS" in model:
             model_name, api_key = env_value.split(",")


### PR DESCRIPTION
## Summary
This PR fixes Anthropic Claude 4.7 Opus graph generation by stopping the backend from sending the deprecated `temperature` parameter for that model.

## What changed
- Updated Anthropic model initialization in `backend/src/llm.py`
- Preserved `temperature=0` for other Anthropic models
- Omitted `temperature` specifically for `claude-opus-4-7`

## Validation
- Ran a focused local backend validation using the repo virtualenv and a mocked `ChatAnthropic` constructor
- Verified `claude-opus-4-7` is created without `temperature`
- Verified `claude-sonnet-4-6` still receives `temperature=0`