### PR TITLE
Fix layout break on zoom due to drawer state mismatch

### DIFF
--- a/frontend/src/components/Layout/PageLayout.tsx
+++ b/frontend/src/components/Layout/PageLayout.tsx
@@ -229,6 +229,16 @@ const PageLayout: React.FC = () => {
     }
   }, [isAuthenticated, user?.email]);
 
+  useEffect(() => {
+    if (!isLargeDesktop) {
+      setIsLeftExpanded(false);
+      setIsRightExpanded(false);
+      setShowDrawerChatbot(false);
+    } else {
+      setShowDrawerChatbot(true);
+    }
+  }, [isLargeDesktop]);
+
   const { cancel } = useSpeechSynthesis();
   const { setActiveSpotlight } = useSpotlightContext();
   const isYoutubeOnly = useMemo(


### PR DESCRIPTION
This PR fixes a UI breaking issue when the side chat (right drawer) is opened and the browser zoom/resolution is increased beyond 100%.


**Breaking UI:**
https://github.com/user-attachments/assets/22f98c0d-0eb3-4ded-9853-524a8025fe55

