### PR TITLE
fix: suppress intentional E402 in wikipedia.py with noqa comments

### DIFF
--- a/backend/src/document_sources/wikipedia.py
+++ b/backend/src/document_sources/wikipedia.py
@@ -2,9 +2,9 @@ import logging
 import wikipedia
 wikipedia.set_user_agent("llm-graph-builder/1.0")
 
-from langchain_community.document_loaders import WikipediaLoader
-from requests.exceptions import JSONDecodeError
-from src.shared.llm_graph_builder_exception import LLMGraphBuilderException
+from langchain_community.document_loaders import WikipediaLoader  # noqa: E402
+from requests.exceptions import JSONDecodeError  # noqa: E402
+from src.shared.llm_graph_builder_exception import LLMGraphBuilderException  # noqa: E402
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

Closes #1544

Runs `ruff check backend/` — the repo is already clean except for three `E402` violations in `wikipedia.py`. These are intentional: `wikipedia.set_user_agent()` must be called before `WikipediaLoader` is imported to set the correct user agent string. Auto-fixing these would break functionality.

Added `# noqa: E402` comments to make the intentional ordering explicit and bring the backend to zero ruff warnings.

```
ruff check backend/
All checks passed!
```