### PR TITLE
Migrate off langchain_experimental and langchain_community (#1571)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,9 +19,7 @@ langchain==1.3.9
 langchain-aws==1.5.0
 langchain-anthropic==1.4.3
 langchain-fireworks==1.4.2
-langchain-community==0.4.1
 langchain-core==1.4.7
-langchain-experimental==0.4.1
 langchain_google_genai==4.2.3
 langchain-groq==1.1.2
 langchain-openai==1.3.2

--- a/backend/src/document_sources/gcs_bucket.py
+++ b/backend/src/document_sources/gcs_bucket.py
@@ -1,9 +1,9 @@
 import os
 import logging
 import io
+import tempfile
 import time
 from google.cloud import storage
-from langchain_community.document_loaders import GCSFileLoader
 from langchain_core.documents import Document
 from PyPDF2 import PdfReader
 from src.shared.llm_graph_builder_exception import LLMGraphBuilderException
@@ -106,6 +106,33 @@ def gcs_loader_func(file_path):
     loader, _ = load_document_content(file_path)
     return loader
 
+def load_documents_from_gcs_blob(storage_client, bucket_name, blob, blob_name):
+    """
+    Downloads a GCS blob to a temp file and loads it, replicating the behaviour of
+    langchain_community.document_loaders.GCSFileLoader without that dependency.
+
+    Args:
+        storage_client: google.cloud.storage.Client instance.
+        bucket_name (str): GCS bucket name.
+        blob: google.cloud.storage.Blob instance to download.
+        blob_name (str): Name of the blob in the bucket.
+
+    Returns:
+        list: List of Document objects loaded from the blob.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file_path = os.path.join(temp_dir, os.path.basename(blob_name))
+        blob.download_to_filename(file_path)
+        loader = gcs_loader_func(file_path)
+        docs = loader.load()
+        custom_metadata = storage_client.bucket(bucket_name).get_blob(blob_name).metadata
+        for doc in docs:
+            if "source" in doc.metadata:
+                doc.metadata["source"] = f"gs://{bucket_name}/{blob_name}"
+            if custom_metadata:
+                doc.metadata.update(custom_metadata)
+        return docs
+
 def get_documents_from_gcs(gcs_project_id, gcs_bucket_name, gcs_bucket_folder, gcs_blob_filename, access_token=None):
     """
     Loads documents from a GCS bucket, handling both public and token-based access.
@@ -138,13 +165,7 @@ def get_documents_from_gcs(gcs_project_id, gcs_bucket_name, gcs_bucket_folder, g
             bucket = storage_client.bucket(gcs_bucket_name)
             blob = bucket.blob(blob_name)
             if blob.exists():
-                loader = GCSFileLoader(
-                    project_name=gcs_project_id,
-                    bucket=gcs_bucket_name,
-                    blob=blob_name,
-                    loader_func=gcs_loader_func
-                )
-                pages = loader.load()
+                pages = load_documents_from_gcs_blob(storage_client, gcs_bucket_name, blob, blob_name)
             else:
                 raise LLMGraphBuilderException('File does not exist, Please re-upload the file and try again.')
         else:

--- a/backend/src/document_sources/local_file.py
+++ b/backend/src/document_sources/local_file.py
@@ -1,7 +1,7 @@
 import logging
 from pathlib import Path
 import chardet
-from langchain_community.document_loaders import PyMuPDFLoader, UnstructuredFileLoader
+import pymupdf
 from langchain_core.documents import Document
 from langchain_core.document_loaders import BaseLoader
 
@@ -17,6 +17,50 @@ class ListLoader(BaseLoader):
         Returns the list of documents.
         """
         return self.documents
+
+class PyMuPDFLoader:
+    """
+    Minimal drop-in replacement for langchain_community.document_loaders.PyMuPDFLoader
+    (mode="page"): loads one Document per PDF page using PyMuPDF directly.
+    """
+    def __init__(self, file_path):
+        self.file_path = str(file_path)
+
+    def load(self):
+        pages = []
+        with pymupdf.open(self.file_path) as pdf_doc:
+            total_pages = len(pdf_doc)
+            for page in pdf_doc:
+                pages.append(Document(
+                    page_content=page.get_text(),
+                    metadata={'source': self.file_path, 'page': page.number, 'total_pages': total_pages}
+                ))
+        return pages
+
+class UnstructuredFileLoader:
+    """
+    Minimal drop-in replacement for langchain_community.document_loaders.UnstructuredFileLoader
+    (mode="elements"): loads one Document per unstructured element.
+    """
+    def __init__(self, file_path, mode="elements", autodetect_encoding=True):
+        self.file_path = str(file_path)
+        self.autodetect_encoding = autodetect_encoding
+
+    def load(self):
+        from unstructured.partition.auto import partition
+        elements = partition(filename=self.file_path, autodetect_encoding=self.autodetect_encoding)
+        documents = []
+        for element in elements:
+            metadata = {'source': self.file_path}
+            if hasattr(element, 'metadata'):
+                metadata.update(element.metadata.to_dict())
+            if hasattr(element, 'category'):
+                metadata['category'] = element.category
+            element_id = element.to_dict().get('element_id')
+            if element_id:
+                metadata['element_id'] = element_id
+            documents.append(Document(page_content=str(element), metadata=metadata))
+        return documents
 
 def detect_encoding(file_path):
     """

--- a/backend/src/document_sources/s3_bucket.py
+++ b/backend/src/document_sources/s3_bucket.py
@@ -4,7 +4,6 @@ import tempfile
 from urllib.parse import urlparse
 
 import boto3
-from langchain_community.document_loaders import S3DirectoryLoader
 
 from src.shared.llm_graph_builder_exception import LLMGraphBuilderException
 from .local_file import load_document_content
@@ -59,41 +58,6 @@ def get_s3_files_info(s3_url, aws_access_key_id=None, aws_secret_access_key=None
         error_message = str(exc)
         logger.error("Error while reading files from s3: %s", error_message)
         raise Exception(error_message) from exc
-
-
-def get_s3_pdf_content(s3_url, aws_access_key_id=None, aws_secret_access_key=None):
-    """
-    Loads and splits PDF content from an S3 bucket if the path ends with .pdf.
-
-    Args:
-        s3_url (str): The S3 URL to the PDF file.
-        aws_access_key_id (str, optional): AWS access key ID.
-        aws_secret_access_key (str, optional): AWS secret access key.
-
-    Returns:
-        list or None: List of Document objects if PDF, else None.
-
-    Raises:
-        Exception: If reading content from S3 fails.
-    """
-    try:
-        parsed_url = urlparse(s3_url)
-        bucket_name = parsed_url.netloc
-        logger.info('bucket name : %s', bucket_name)
-        directory = parsed_url.path.lstrip('/')
-        if directory.endswith('.pdf'):
-            loader = S3DirectoryLoader(
-                bucket_name,
-                prefix=directory,
-                aws_access_key_id=aws_access_key_id,
-                aws_secret_access_key=aws_secret_access_key
-            )
-            pages = loader.load_and_split()
-            return pages
-        return None
-    except Exception as exc:
-        logger.error("getting error while reading content from s3 files:%s", exc)
-        raise Exception(exc) from exc
 
 
 def download_s3_file(s3_client, bucket, file_key, local_path):

--- a/backend/src/document_sources/web_pages.py
+++ b/backend/src/document_sources/web_pages.py
@@ -1,4 +1,3 @@
-# from langchain_community.document_loaders import WebBaseLoader
 from langchain_core.documents import Document
 import requests
 from bs4 import BeautifulSoup

--- a/backend/src/document_sources/wikipedia.py
+++ b/backend/src/document_sources/wikipedia.py
@@ -3,7 +3,6 @@ from langchain_core.documents import Document
 import wikipedia
 wikipedia.set_user_agent("llm-graph-builder/1.0")
 
-# from langchain_community.document_loaders import WikipediaLoader
 from requests.exceptions import JSONDecodeError
 from src.shared.llm_graph_builder_exception import LLMGraphBuilderException
 
@@ -31,16 +30,8 @@ def get_documents_from_wikipedia(wiki_query: str, language: str):
         try:
             page = wikipedia.page(results[0], auto_suggest=False, redirect=True, preload=False)
             docs.append(Document(page_content=page.content[:100000], metadata={"title": page.title,"source": page.url}))
-        # break  # Only load the first result
         except wikipedia.exceptions.DisambiguationError as e:
             logger.warning("Disambiguation error for query '%s': %s", wiki_query, str(e))
-        # pages = WikipediaLoader(
-        #     query=wiki_query,
-        #     lang=language,
-        #     load_all_available_meta=False,
-        #     doc_content_chars_max=100000,
-        #     load_max_docs=1
-        # ).load()
         file_name = wiki_query.strip()
         logger.info("Total Pages from Wikipedia = %d", len(docs))
         return file_name, docs

--- a/backend/src/llm.py
+++ b/backend/src/llm.py
@@ -3,11 +3,9 @@ from langchain_core.documents import Document
 from langchain_openai import ChatOpenAI, AzureChatOpenAI
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_groq import ChatGroq
-from langchain_experimental.graph_transformers.diffbot import DiffbotGraphTransformer
 from langchain_neo4j import LLMGraphTransformer
-from langchain_experimental.graph_transformers.llm import _Graph
-# from src.shared.diffbot import DiffbotGraphTransformer, Graph
-# from src.shared.diffbot import Graph
+from langchain_neo4j.graph_transformers.llm import _Graph
+from src.shared.diffbot import DiffbotGraphTransformer
 from langchain_anthropic import ChatAnthropic
 from langchain_fireworks import ChatFireworks
 from langchain_aws import ChatBedrock

--- a/backend/src/shared/common_fn.py
+++ b/backend/src/shared/common_fn.py
@@ -16,13 +16,13 @@ from langchain_google_genai import GoogleGenerativeAIEmbeddings
 from langchain_openai import OpenAIEmbeddings
 from langchain_neo4j import Neo4jGraph
 from neo4j.exceptions import TransientError
-from langchain_community.graphs.graph_document import GraphDocument
+from langchain_neo4j.graphs.graph_document import GraphDocument
 from typing import List
 import re
 import time
 from pathlib import Path
 import boto3
-from langchain_community.embeddings import BedrockEmbeddings
+from langchain_aws import BedrockEmbeddings
 from langchain_core.callbacks import BaseCallbackHandler
 
 

--- a/backend/src/shared/diffbot.py
+++ b/backend/src/shared/diffbot.py
@@ -1,41 +1,281 @@
+"""
+Standalone replacement for `langchain_experimental.graph_transformers.diffbot.DiffbotGraphTransformer`.
+
+langchain_experimental is being sunset, so this module reimplements the Diffbot NLP
+graph transformer against `langchain_neo4j`'s GraphDocument/Node/Relationship types
+instead of `langchain_community`'s.
+"""
+import os
+from enum import Enum
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
 import requests
-from dataclasses import dataclass, field
-from typing import List, Optional
+from langchain_core.documents import Document
+from langchain_neo4j.graphs.graph_document import GraphDocument, Node, Relationship
+
+
+class TypeOption(str, Enum):
+    FACTS = "facts"
+    ENTITIES = "entities"
+    SENTIMENT = "sentiment"
+
+
+def format_property_key(s: str) -> str:
+    """Formats a string to be used as a property key."""
+    words = s.split()
+    if not words:
+        return s
+    first_word = words[0].lower()
+    capitalized_words = [word.capitalize() for word in words[1:]]
+    return "".join([first_word] + capitalized_words)
+
+
+class NodesList:
+    """List of nodes with associated properties.
+
+    Attributes:
+        nodes (Dict[Tuple, Any]): Stores nodes as keys and their properties as values.
+            Each key is a tuple where the first element is the
+            node ID and the second is the node type.
+    """
+
+    def __init__(self) -> None:
+        self.nodes: Dict[Tuple[Union[str, int], str], Any] = dict()
+
+    def add_node_property(
+        self, node: Tuple[Union[str, int], str], properties: Dict[str, Any]
+    ) -> None:
+        """Adds a node, merging properties if the node already exists."""
+        if node not in self.nodes:
+            self.nodes[node] = properties
+        else:
+            self.nodes[node].update(properties)
+
+    def return_node_list(self) -> List[Node]:
+        """Returns the nodes as a list of `Node` objects."""
+        nodes = [
+            Node(id=key[0], type=key[1], properties=self.nodes[key])
+            for key in self.nodes
+        ]
+        return nodes
+
+
+# Properties that should be treated as node properties instead of relationships
+FACT_TO_PROPERTY_TYPE = [
+    "Date",
+    "Number",
+    "Job title",
+    "Cause of death",
+    "Organization type",
+    "Academic title",
+]
+
+
+schema_mapping = [
+    ("HEADQUARTERS", "ORGANIZATION_LOCATIONS"),
+    ("RESIDENCE", "PERSON_LOCATION"),
+    ("ALL_PERSON_LOCATIONS", "PERSON_LOCATION"),
+    ("CHILD", "HAS_CHILD"),
+    ("PARENT", "HAS_PARENT"),
+    ("CUSTOMERS", "HAS_CUSTOMER"),
+    ("SKILLED_AT", "INTERESTED_IN"),
+]
+
+
+class SimplifiedSchema:
+    """Simplified schema mapping."""
+
+    def __init__(self) -> None:
+        self.schema = dict()
+        for row in schema_mapping:
+            self.schema[row[0]] = row[1]
+
+    def get_type(self, type: str) -> str:
+        """Returns the simplified schema type for a given original type, if any."""
+        return self.schema.get(type, type)
+
 
 class DiffbotGraphTransformer:
-    def __init__(self, diffbot_api_key: str, extract_types: List[str] = ["facts"]):
-        self.api_key = diffbot_api_key
+    """Transform documents into graph documents using the Diffbot NLP API.
+
+    Example:
+        .. code-block:: python
+          from src.shared.diffbot import DiffbotGraphTransformer
+          from langchain_core.documents import Document
+
+          diffbot_nlp = DiffbotGraphTransformer(diffbot_api_key="DIFFBOT_API_KEY")
+
+          document = Document(page_content="Mike Tunge is the CEO of Diffbot.")
+          graph_documents = diffbot_nlp.convert_to_graph_documents([document])
+    """
+
+    def __init__(
+        self,
+        diffbot_api_key: Optional[str] = None,
+        fact_confidence_threshold: float = 0.7,
+        include_qualifiers: bool = True,
+        include_evidence: bool = True,
+        simplified_schema: bool = True,
+        extract_types: List[TypeOption] = [TypeOption.FACTS],
+        *,
+        include_confidence: bool = False,
+    ) -> None:
+        """
+        Args:
+            diffbot_api_key (str): The API key for Diffbot's NLP services.
+            fact_confidence_threshold (float): Minimum confidence level for facts to be included.
+            include_qualifiers (bool): Whether to include qualifiers in the relationships.
+            include_evidence (bool): Whether to include evidence for the relationships.
+            simplified_schema (bool): Whether to use a simplified schema for relationships.
+            extract_types (List[TypeOption]): Data types to extract (facts, entities, sentiment).
+            include_confidence (bool): Whether to include confidence scores on nodes and rels.
+        """
+        self.diffbot_api_key = diffbot_api_key or os.environ.get("DIFFBOT_API_KEY")
+        if not self.diffbot_api_key:
+            raise ValueError(
+                "`diffbot_api_key` must be provided or set via the `DIFFBOT_API_KEY` env var."
+            )
+        self.fact_threshold_confidence = fact_confidence_threshold
+        self.include_qualifiers = include_qualifiers
+        self.include_evidence = include_evidence
+        self.include_confidence = include_confidence
+        self.simplified_schema = None
+        if simplified_schema:
+            self.simplified_schema = SimplifiedSchema()
+        if not extract_types:
+            raise ValueError(
+                "`extract_types` cannot be an empty array. "
+                "Allowed values are 'facts', 'entities', or both."
+            )
         self.extract_types = extract_types
 
-    def convert_to_graph_documents(self, documents):
-        graph_docs = []
-        for doc in documents:
-            response = requests.post(
-                    "https://nl.diffbot.com/v1/",
-                    params={"token": self.api_key},
-                    json={
-                    "content": [{"value": doc.page_content}],
-                    "conf": {
-                    "types": self.extract_types,
-                    "threshold": 0.7
-                        }
-                    }
+    def nlp_request(self, text: str) -> Dict[str, Any]:
+        """Makes an API request to the Diffbot NLP endpoint."""
+        # Relationship extraction only works for English
+        payload = {
+            "content": text,
+            "lang": "en",
+        }
+        fields = ",".join(self.extract_types)
+        host = "nl.diffbot.com"
+        url = f"https://{host}/v1/?fields={fields}&token={self.diffbot_api_key}&language=en"
+        result = requests.post(url, data=payload)
+        return result.json()
+
+    def process_response(
+        self, payload: Dict[str, Any], document: Document
+    ) -> GraphDocument:
+        """Transforms the Diffbot NLP response into a `GraphDocument`."""
+        # Return empty result if there are no facts
+        if ("facts" not in payload or not payload["facts"]) and (
+            "entities" not in payload or not payload["entities"]
+        ):
+            return GraphDocument(nodes=[], relationships=[], source=document)
+
+        # Nodes are a custom class because we need to deduplicate
+        nodes_list = NodesList()
+        if "entities" in payload and payload["entities"]:
+            for record in payload["entities"]:
+                # Ignore if it doesn't have a type
+                if not record["allTypes"]:
+                    continue
+                source_id = (
+                    record["allUris"][0] if record["allUris"] else record["name"]
                 )
-            graph_docs.append(response.json())
-        return graph_docs
-        
-@dataclass
-class GraphNode:
-    id: str
-    type: str
+                source_label = record["allTypes"][0]["name"].capitalize()
+                source_name = record["name"]
+                nodes_list.add_node_property(
+                    (source_id, source_label), {"name": source_name}
+                )
+                if record.get("sentiment") is not None:
+                    nodes_list.add_node_property(
+                        (source_id, source_label),
+                        {"sentiment": record.get("sentiment")},
+                    )
+                if self.include_confidence:
+                    nodes_list.add_node_property(
+                        (source_id, source_label),
+                        {"confidence": record.get("confidence")},
+                    )
 
-@dataclass
-class GraphRelationship:
-    source: GraphNode
-    target: GraphNode
-    type: str
+        relationships = list()
+        # Relationships are a list because we don't deduplicate them
+        if "facts" in payload and payload["facts"]:
+            for record in payload["facts"]:
+                # Skip if the fact is below the threshold confidence
+                if record["confidence"] < self.fact_threshold_confidence:
+                    continue
+                if not record["value"]["allTypes"]:
+                    continue
 
-@dataclass
-class Graph:
-    nodes: List[GraphNode] = field(default_factory=list)
-    relationships: List[GraphRelationship] = field(default_factory=list)
+                # Source node
+                source_id = (
+                    record["entity"]["allUris"][0]
+                    if record["entity"]["allUris"]
+                    else record["entity"]["name"]
+                )
+                source_label = record["entity"]["allTypes"][0]["name"].capitalize()
+                source_name = record["entity"]["name"]
+                source_node = Node(id=source_id, type=source_label)
+                nodes_list.add_node_property(
+                    (source_id, source_label), {"name": source_name}
+                )
+
+                # Target node
+                target_id = (
+                    record["value"]["allUris"][0]
+                    if record["value"]["allUris"]
+                    else record["value"]["name"]
+                )
+                target_label = record["value"]["allTypes"][0]["name"].capitalize()
+                target_name = record["value"]["name"]
+                # Some facts are better suited as node properties
+                if target_label in FACT_TO_PROPERTY_TYPE:
+                    nodes_list.add_node_property(
+                        (source_id, source_label),
+                        {format_property_key(record["property"]["name"]): target_name},
+                    )
+                else:  # Define relationship
+                    target_node = Node(id=target_id, type=target_label)
+                    nodes_list.add_node_property(
+                        (target_id, target_label), {"name": target_name}
+                    )
+                    rel_type = record["property"]["name"].replace(" ", "_").upper()
+                    if self.simplified_schema:
+                        rel_type = self.simplified_schema.get_type(rel_type)
+
+                    rel_properties = dict()
+                    relationship_evidence = [el["passage"] for el in record["evidence"]][0]
+                    if self.include_evidence:
+                        rel_properties.update({"evidence": relationship_evidence})
+                    if self.include_confidence:
+                        rel_properties.update({"confidence": record["confidence"]})
+                    if self.include_qualifiers and record.get("qualifiers"):
+                        for property in record["qualifiers"]:
+                            prop_key = format_property_key(property["property"]["name"])
+                            rel_properties[prop_key] = property["value"]["name"]
+
+                    relationship = Relationship(
+                        source=source_node,
+                        target=target_node,
+                        type=rel_type,
+                        properties=rel_properties,
+                    )
+                    relationships.append(relationship)
+
+        return GraphDocument(
+            nodes=nodes_list.return_node_list(),
+            relationships=relationships,
+            source=document,
+        )
+
+    def convert_to_graph_documents(
+        self, documents: Sequence[Document]
+    ) -> List[GraphDocument]:
+        """Converts a sequence of documents into graph documents via the Diffbot NLP API."""
+        results = []
+        for document in documents:
+            raw_results = self.nlp_request(document.page_content)
+            graph_document = self.process_response(raw_results, document)
+            results.append(graph_document)
+        return results


### PR DESCRIPTION
Closes #1571

`langchain_experimental` and `langchain_community` are both being sunset. This PR finishes the migration off of them for the remaining backend usages (Wikipedia/web page loaders and chat history were already migrated in `dev`).

## Changes
- **Diffbot**: Reimplemented `DiffbotGraphTransformer` in `backend/src/shared/diffbot.py`, built on `langchain_neo4j.graphs.graph_document` (`GraphDocument`/`Node`/`Relationship`) instead of `langchain_community`'s. `llm.py`'s `_Graph` import now comes from `langchain_neo4j.graph_transformers.llm` (equivalent shape, ships with `langchain-neo4j==0.10.0`).
- **Local file loading**: Replaced `PyMuPDFLoader`/`UnstructuredFileLoader` in `local_file.py` with minimal drop-in implementations that call `pymupdf`/`unstructured.partition.auto.partition` directly, preserving the exact metadata shape downstream code depends on (e.g. the `'page'` key used by `create_chunks.py`).
- **S3**: Removed `get_s3_pdf_content`/`S3DirectoryLoader` from `s3_bucket.py` — this was dead code, never called (the real S3 ingestion path already downloads the file and reuses the local file loader).
- **GCS**: Replaced `GCSFileLoader` in `gcs_bucket.py` with a direct download-to-tempdir + local-loader implementation that replicates the same source/metadata overrides as the original.
- **common_fn.py**: `GraphDocument` now from `langchain_neo4j`, `BedrockEmbeddings` now from `langchain_aws` (drop-in compatible fields).
- **requirements.txt**: Dropped the explicit `langchain-experimental` and `langchain-community` pins.
- Minor cleanup of stale commented-out `langchain_community` import remnants in `web_pages.py`/`wikipedia.py`.

## Testing
- Confirmed zero remaining `langchain_experimental`/`langchain_community` imports in `backend/src`.
- Verified real imports of every touched module plus the full FastAPI app (`score.py`) using the backend's venv.
- Functionally tested `DiffbotGraphTransformer.process_response` with a fake API payload — produces correct `langchain_neo4j` `GraphDocument`/`Node`/`Relationship` objects.
- Functionally tested the new PDF and text loaders end-to-end via `get_documents_from_file_by_path`.
- Verified this branch merges cleanly into `dev` with no conflicts (`git merge-tree`).
