### PR TITLE
feat: add OrcaRouter as a named LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ This application allows you to upload files from various sources (local machine,
 9. Ollama (dev deployed version)
 10. Deepseek (dev deployed version)
 11. Other OpenAI-compatible base URL models (dev deployed version)
+12. OrcaRouter (dev deployed version)
 
 
 ### **Token Usage Tracking**
@@ -125,7 +126,14 @@ Run the application using the default `docker-compose` configuration.
    LLM_MODEL_CONFIG_ANTHROPIC_CLAUDE_4_7_OPUS="claude-opus-4-7,anthropic_api_key"
    ```
 
-3. **Input Sources:**  
+3. **OrcaRouter Models:**
+   OrcaRouter is an OpenAI-compatible model routing gateway. Set the model to any upstream model your OrcaRouter key can access (e.g. `anthropic/claude-sonnet-4.6`, `openai/gpt-5.5`):
+   ```bash
+   LLM_MODEL_CONFIG_ORCAROUTER_CLAUDE_4_6_SONNET="anthropic/claude-sonnet-4.6,orcarouter_api_key"
+   LLM_MODEL_CONFIG_ORCAROUTER_GPT_5_5="openai/gpt-5.5,orcarouter_api_key"
+   ```
+
+4. **Input Sources:**  
    By default, the following sources are enabled: `local`, `YouTube`, `Wikipedia`, `AWS S3`, and `web`.  
    To add Google Cloud Storage (GCS) integration, include `gcs` and your Google client ID:
    ```bash

--- a/backend/example.env
+++ b/backend/example.env
@@ -32,6 +32,9 @@ LLM_MODEL_CONFIG_DIFFBOT="diffbot,diffbot_api_key"
 LLM_MODEL_CONFIG_GROQ_LLAMA3_1_8B="llama-3.1-8b-instant,base_url,groq_api_key"
 LLM_MODEL_CONFIG_ANTHROPIC_CLAUDE_4_6_SONNET="claude-sonnet-4-6,anthropic_api_key"
 LLM_MODEL_CONFIG_ANTHROPIC_CLAUDE_4_7_OPUS="claude-opus-4-7,anthropic_api_key"
+# OrcaRouter is an OpenAI-compatible model routing gateway. The model name can be any upstream model your OrcaRouter key can access.
+LLM_MODEL_CONFIG_ORCAROUTER_CLAUDE_4_6_SONNET="anthropic/claude-sonnet-4.6,orcarouter_api_key"
+LLM_MODEL_CONFIG_ORCAROUTER_GPT_5_5="openai/gpt-5.5,orcarouter_api_key"
 LLM_MODEL_CONFIG_LLAMA4_MAVERICK="Llama-4-Maverick-17B-128E-Instruct-FP8,api_endpoint,api_key"
 LLM_MODEL_CONFIG_AZURE_AI_GPT_4O="gpt-4o,https://YOUR-ENDPOINT.openai.azure.com/,azure_api_key,api_version"
 # Internal app token `fireworks_qwen3_6` resolves to the Fireworks serverless slug `qwen3p6-plus`.

--- a/backend/src/llm.py
+++ b/backend/src/llm.py
@@ -54,6 +54,16 @@ def get_llm(model: str):
                 },
             
             )
+        elif "ORCAROUTER" in model:
+            model_name, api_key = env_value.split(",")
+            llm = ChatOpenAI(
+                api_key=api_key,
+                base_url="https://api.orcarouter.ai/v1",
+                model=model_name,
+                temperature=0,
+                callbacks=callback_manager,
+            )
+
         elif "OPENAI" in model:
             model_name, api_key = env_value.split(",")
             if "MINI" in model:

--- a/frontend/src/utils/Constants.ts
+++ b/frontend/src/utils/Constants.ts
@@ -26,6 +26,8 @@ export const llms = import.meta.env?.VITE_LLM_MODELS?.trim()
       'fireworks_gpt_oss',
       'fireworks_kimi_k2p6',
       'fireworks_glm_5.1',
+      'orcarouter_gpt_5.5',
+      'orcarouter_claude_4.6_sonnet',
     ];
 
 export const prodllms = import.meta.env.VITE_LLM_MODELS_PROD?.trim()


### PR DESCRIPTION
## What does this PR do?

Adds OrcaRouter as a named LLM provider in `get_llm`, alongside the existing OpenAI, Gemini, Anthropic, Fireworks, Groq, Bedrock, and Ollama branches.

Adds [OrcaRouter](https://www.orcarouter.ai) as a model provider. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key. It also provides gateway-level security controls for AI agents.

I'm an engineer on the OrcaRouter team.

## Why a named branch?

`get_llm` dispatches on the model slug (`LLM_MODEL_CONFIG_*`) to provider-specific branches. This registers OrcaRouter the same way Groq/Fireworks/Bedrock are registered, so `LLM_MODEL_CONFIG_ORCAROUTER_GPT_5_5="openai/gpt-5.5,<key>"` resolves to `https://api.orcarouter.ai/v1` without relying on the generic 3-field (`model,api_endpoint,api_key`) base-URL format. The branch sits ahead of the `OPENAI` check, so a slug like `orcarouter_openai_gpt_5.5` stays on the OrcaRouter endpoint instead of silently routing to api.openai.com (which would reject a `sk-orca-*` key).

## Changes

- `backend/src/llm.py` — new `ORCAROUTER` branch: `ChatOpenAI(base_url="https://api.orcarouter.ai/v1")`, config format `model,api_key`.
- `backend/example.env` — example configs for `orcarouter_claude_4.6_sonnet` and `orcarouter_gpt_5.5`.
- `frontend/src/utils/Constants.ts` — add `orcarouter_gpt_5.5` and `orcarouter_claude_4.6_sonnet` to the model picker.
- `README.md` — add OrcaRouter to the supported LLMs list and a config example.

## Test plan

- Dispatch: `get_llm("orcarouter_gpt_5.5")` returns a `ChatOpenAI` bound to `https://api.orcarouter.ai/v1` (verified via `openai_api_base`).
- Ordering: `get_llm("orcarouter_openai_gpt_5.5")` also stays on the OrcaRouter base URL, not the OpenAI branch.
- Live: a real `sk-orca-*` key through the new branch returns a chat completion from `openai/gpt-5.5`.
- Regression: existing OpenAI (no base URL), Anthropic (`ChatAnthropic`), and generic base-URL branches behave as before.
